### PR TITLE
Adds human-friendly stats on the stress test timings.

### DIFF
--- a/coreznet/go.mod
+++ b/coreznet/go.mod
@@ -9,7 +9,7 @@ replace (
 )
 
 require (
-	github.com/CoreumFoundation/coreum-tools v0.1.3
+	github.com/CoreumFoundation/coreum-tools v0.1.4-rc1
 	github.com/cosmos/cosmos-sdk v0.45.4
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.4.0

--- a/coreznet/go.sum
+++ b/coreznet/go.sum
@@ -62,8 +62,8 @@ github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQcITbvhmL4+C4cKA87NW0tfm3Kl9VXRoPywFg=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
-github.com/CoreumFoundation/coreum-tools v0.1.3 h1:VfyNeYPmy+SrHBQst8md1mWBAAVrXjs34JyVVlVaQEg=
-github.com/CoreumFoundation/coreum-tools v0.1.3/go.mod h1:3zOaSSZQHpOj4iBbNqH0auelYVMeGrnZ4yzhTLU5pUw=
+github.com/CoreumFoundation/coreum-tools v0.1.4-rc1 h1:C1b8XWOpjiJqfbvT//lgFlDkK9HbJmmh7g0kR4nQMrg=
+github.com/CoreumFoundation/coreum-tools v0.1.4-rc1/go.mod h1:3zOaSSZQHpOj4iBbNqH0auelYVMeGrnZ4yzhTLU5pUw=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=


### PR DESCRIPTION
Adds human-friendly stats on the stress test timings.
Reports corezstress instance-wide tx throughput per second.

This changeset uses `pace` package from [coreum-tools @ v0.1.4-rc1](https://github.com/CoreumFoundation/coreum-tools/tree/f/pace). If the tools-related PR (https://github.com/CoreumFoundation/coreum-tools/pull/8) gets merged, this could point to `v0.1.4`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coreumfoundation/coreum/45)
<!-- Reviewable:end -->
