### PR TITLE
`coreznet`: Change the logic and names of `PreFunc` and `PostFunc`

### DIFF
--- a/coreznet/infra/apps/cored/cored.go
+++ b/coreznet/infra/apps/cored/cored.go
@@ -201,7 +201,7 @@ func (c Cored) Deployment() infra.Deployment {
 				return args
 			},
 			Ports: infra.PortsToMap(c.ports),
-			PreFunc: func() error {
+			PrepareFunc: func() error {
 				c.mu.RLock()
 				defer c.mu.RUnlock()
 
@@ -217,7 +217,7 @@ func (c Cored) Deployment() infra.Deployment {
 				c.genesis.Save(c.homeDir)
 				return nil
 			},
-			PostFunc: func(ctx context.Context, deployment infra.DeploymentInfo) error {
+			ConfigureFunc: func(ctx context.Context, deployment infra.DeploymentInfo) error {
 				return c.saveClientWrapper(c.config.WrapperDir, deployment.FromHostIP)
 			},
 		},

--- a/coreznet/infra/apps/hasura/hasura.go
+++ b/coreznet/infra/apps/hasura/hasura.go
@@ -100,10 +100,7 @@ func (h Hasura) Deployment() infra.Deployment {
 					infra.IsRunning(h.postgres),
 				},
 			},
-			PostFunc: func(ctx context.Context, deployment infra.DeploymentInfo) error {
-				if h.Info().Status != infra.AppStatusNotDeployed {
-					return nil
-				}
+			ConfigureFunc: func(ctx context.Context, deployment infra.DeploymentInfo) error {
 				metadata := h.prepareMetadata()
 				metaURL := url.URL{Scheme: "http", Host: infra.JoinProtoIPPort("", deployment.FromHostIP, h.port), Path: "/v1/metadata"}
 

--- a/coreznet/infra/apps/postgres/postgres.go
+++ b/coreznet/infra/apps/postgres/postgres.go
@@ -103,8 +103,8 @@ func (p Postgres) Deployment() infra.Deployment {
 			Ports: map[string]int{
 				"sql": p.port,
 			},
-			PostFunc: func(ctx context.Context, deployment infra.DeploymentInfo) error {
-				if p.schemaLoaderFunc == nil || p.Info().Status != infra.AppStatusNotDeployed {
+			ConfigureFunc: func(ctx context.Context, deployment infra.DeploymentInfo) error {
+				if p.schemaLoaderFunc == nil {
 					return nil
 				}
 


### PR DESCRIPTION
- `PreFunc` --> `PrepareFunc`
- `PostFunc` --> `ConfigureFunc`
- `ConfigureFunc` is executed only on first deployment
- Improve comments

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coreumfoundation/coreum/83)
<!-- Reviewable:end -->
