### PR TITLE
`znet`: Add dependencies to `spec` and stop containers in the sequence determined by information stored there

### DIFF
--- a/crust/infra/targets/docker.go
+++ b/crust/infra/targets/docker.go
@@ -35,10 +35,9 @@ const (
 // FIXME (wojciech): Entire logic here could be easily implemented by using docker API instead of binary execution
 
 // NewDocker creates new docker target
-func NewDocker(config infra.Config, mode infra.Mode, spec *infra.Spec) *Docker {
+func NewDocker(config infra.Config, spec *infra.Spec) *Docker {
 	return &Docker{
 		config: config,
-		mode:   mode,
 		spec:   spec,
 	}
 }
@@ -46,7 +45,6 @@ func NewDocker(config infra.Config, mode infra.Mode, spec *infra.Spec) *Docker {
 // Docker is the target deploying apps to docker
 type Docker struct {
 	config infra.Config
-	mode   infra.Mode
 	spec   *infra.Spec
 }
 
@@ -54,12 +52,12 @@ type Docker struct {
 func (d *Docker) Stop(ctx context.Context) error {
 	dependencies := map[string][]chan struct{}{}
 	readyChs := map[string]chan struct{}{}
-	for _, app := range d.mode {
+	for appName, app := range d.spec.Apps {
 		readyCh := make(chan struct{})
-		readyChs[app.Name()] = readyCh
+		readyChs[appName] = readyCh
 
-		for _, dep := range app.Deployment().Dependencies() {
-			dependencies[dep.Name()] = append(dependencies[dep.Name()], readyCh)
+		for _, depName := range app.Info().DependsOn {
+			dependencies[depName] = append(dependencies[depName], readyCh)
 		}
 	}
 


### PR DESCRIPTION
Previously `docker` stopped apps in correct sequence by looking at `mode`. But there is no guarantee that `mode` is known during creation of the `Docker` struct. Now it works just by accident. The correct approach is to store dependencies in `spec` and act based on information stored there.

`mode` represents applications users would like to run (expected state). `spec` represents application which are running (current state). `Stop` should act based on current state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coreumfoundation/coreum/96)
<!-- Reviewable:end -->
