### PR TITLE
Refuse to add transaction to mempool if gas price is below minimum specified for network

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/cosmos/cosmos-sdk/x/auth"
-	"github.com/cosmos/cosmos-sdk/x/auth/ante"
 	authrest "github.com/cosmos/cosmos-sdk/x/auth/client/rest"
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	authsims "github.com/cosmos/cosmos-sdk/x/auth/simulation"
@@ -84,21 +83,20 @@ import (
 	ibcporttypes "github.com/cosmos/ibc-go/v3/modules/core/05-port/types"
 	ibchost "github.com/cosmos/ibc-go/v3/modules/core/24-host"
 	ibckeeper "github.com/cosmos/ibc-go/v3/modules/core/keeper"
+	"github.com/ignite-hq/cli/ignite/pkg/cosmoscmd"
+	"github.com/ignite-hq/cli/ignite/pkg/openapiconsole"
 	"github.com/spf13/cast"
+	monitoringp "github.com/tendermint/spn/x/monitoringp"
+	monitoringpkeeper "github.com/tendermint/spn/x/monitoringp/keeper"
+	monitoringptypes "github.com/tendermint/spn/x/monitoringp/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmjson "github.com/tendermint/tendermint/libs/json"
 	"github.com/tendermint/tendermint/libs/log"
 	tmos "github.com/tendermint/tendermint/libs/os"
 	dbm "github.com/tendermint/tm-db"
 
-	"github.com/ignite-hq/cli/ignite/pkg/cosmoscmd"
-	"github.com/ignite-hq/cli/ignite/pkg/openapiconsole"
-
-	monitoringp "github.com/tendermint/spn/x/monitoringp"
-	monitoringpkeeper "github.com/tendermint/spn/x/monitoringp/keeper"
-	monitoringptypes "github.com/tendermint/spn/x/monitoringp/types"
-
 	"github.com/CoreumFoundation/coreum/docs"
+	"github.com/CoreumFoundation/coreum/x/auth/ante"
 	// this line is used by starport scaffolding # stargate/app/moduleImport
 )
 
@@ -545,7 +543,7 @@ func New(
 			BankKeeper:      app.BankKeeper,
 			SignModeHandler: encodingConfig.TxConfig.SignModeHandler(),
 			FeegrantKeeper:  app.FeeGrantKeeper,
-			SigGasConsumer:  ante.DefaultSigVerificationGasConsumer,
+			MinGasPrice:     sdk.NewCoin(DefaultNetwork.TokenSymbol(), sdk.NewIntFromBigInt(DefaultNetwork.MinGasPrice())),
 		},
 	)
 	if err != nil {

--- a/app/app.go
+++ b/app/app.go
@@ -543,7 +543,7 @@ func New(
 			BankKeeper:      app.BankKeeper,
 			SignModeHandler: encodingConfig.TxConfig.SignModeHandler(),
 			FeegrantKeeper:  app.FeeGrantKeeper,
-			MinGasPrice:     sdk.NewCoin(DefaultNetwork.TokenSymbol(), sdk.NewIntFromBigInt(DefaultNetwork.MinGasPrice())),
+			MinGasPrice:     sdk.NewCoin(DefaultNetwork.TokenSymbol(), sdk.NewIntFromBigInt(DefaultNetwork.MinDiscountedGasPrice())),
 		},
 	)
 	if err != nil {

--- a/app/network.go
+++ b/app/network.go
@@ -54,9 +54,9 @@ func init() {
 			AddressPrefix: "core",
 			TokenSymbol:   TokenSymbolMain,
 			Fees: FeeConfig{
-				InitialGasPrice: big.NewInt(1500),
-				MinGasPrice:     big.NewInt(1000),
-				TxBankSendGas:   120000,
+				InitialGasPrice:       big.NewInt(1500),
+				MinDiscountedGasPrice: big.NewInt(1000),
+				TxBankSendGas:         120000,
 			},
 		},
 		{
@@ -65,9 +65,9 @@ func init() {
 			AddressPrefix: "devcore",
 			TokenSymbol:   TokenSymbolDev,
 			Fees: FeeConfig{
-				InitialGasPrice: big.NewInt(1500),
-				MinGasPrice:     big.NewInt(1000),
-				TxBankSendGas:   120000,
+				InitialGasPrice:       big.NewInt(1500),
+				MinDiscountedGasPrice: big.NewInt(1000),
+				TxBankSendGas:         120000,
 			},
 		},
 	}
@@ -87,9 +87,9 @@ var networks = map[ChainID]NetworkConfig{}
 
 // FeeConfig is the part of network config defining parameters of our fee model
 type FeeConfig struct {
-	InitialGasPrice *big.Int
-	MinGasPrice     *big.Int
-	TxBankSendGas   uint64
+	InitialGasPrice       *big.Int
+	MinDiscountedGasPrice *big.Int
+	TxBankSendGas         uint64
 }
 
 // NetworkConfig helps initialize Network instance
@@ -105,13 +105,13 @@ type NetworkConfig struct {
 
 // Network holds all the configuration for different predefined networks
 type Network struct {
-	chainID         ChainID
-	genesisTime     time.Time
-	addressPrefix   string
-	tokenSymbol     string
-	initialGasPrice *big.Int
-	minGasPrice     *big.Int
-	txBankSendGas   uint64
+	chainID               ChainID
+	genesisTime           time.Time
+	addressPrefix         string
+	tokenSymbol           string
+	initialGasPrice       *big.Int
+	minDiscountedGasPrice *big.Int
+	txBankSendGas         uint64
 
 	mu             *sync.Mutex
 	fundedAccounts []FundedAccount
@@ -121,16 +121,16 @@ type Network struct {
 // NewNetwork returns a new instance of Network
 func NewNetwork(c NetworkConfig) Network {
 	n := Network{
-		genesisTime:     c.GenesisTime,
-		chainID:         c.ChainID,
-		addressPrefix:   c.AddressPrefix,
-		tokenSymbol:     c.TokenSymbol,
-		initialGasPrice: big.NewInt(0).Set(c.Fees.InitialGasPrice),
-		minGasPrice:     big.NewInt(0).Set(c.Fees.MinGasPrice),
-		txBankSendGas:   c.Fees.TxBankSendGas,
-		mu:              &sync.Mutex{},
-		fundedAccounts:  append([]FundedAccount{}, c.FundedAccounts...),
-		genTxs:          append([]json.RawMessage{}, c.GenTxs...),
+		genesisTime:           c.GenesisTime,
+		chainID:               c.ChainID,
+		addressPrefix:         c.AddressPrefix,
+		tokenSymbol:           c.TokenSymbol,
+		initialGasPrice:       big.NewInt(0).Set(c.Fees.InitialGasPrice),
+		minDiscountedGasPrice: big.NewInt(0).Set(c.Fees.MinDiscountedGasPrice),
+		txBankSendGas:         c.Fees.TxBankSendGas,
+		mu:                    &sync.Mutex{},
+		fundedAccounts:        append([]FundedAccount{}, c.FundedAccounts...),
+		genTxs:                append([]json.RawMessage{}, c.GenTxs...),
 	}
 
 	return n
@@ -292,9 +292,9 @@ func (n Network) InitialGasPrice() *big.Int {
 	return big.NewInt(0).Set(n.initialGasPrice)
 }
 
-// MinGasPrice returns minimum gas price after giving maximum discount
-func (n Network) MinGasPrice() *big.Int {
-	return big.NewInt(0).Set(n.minGasPrice)
+// MinDiscountedGasPrice returns minimum gas price after giving maximum discount
+func (n Network) MinDiscountedGasPrice() *big.Int {
+	return big.NewInt(0).Set(n.minDiscountedGasPrice)
 }
 
 // TxBankSendGas returns gas required by tx bank send

--- a/app/network_test.go
+++ b/app/network_test.go
@@ -37,9 +37,9 @@ func testNetwork() Network {
 		AddressPrefix: "core",
 		TokenSymbol:   TokenSymbolMain,
 		Fees: FeeConfig{
-			InitialGasPrice: big.NewInt(2),
-			MinGasPrice:     big.NewInt(1),
-			TxBankSendGas:   10,
+			InitialGasPrice:       big.NewInt(2),
+			MinDiscountedGasPrice: big.NewInt(1),
+			TxBankSendGas:         10,
 		},
 		FundedAccounts: []FundedAccount{{
 			PublicKey: pubKey,
@@ -232,9 +232,9 @@ func TestNetworkConfigNotMutable(t *testing.T) {
 		AddressPrefix: "core",
 		TokenSymbol:   TokenSymbolMain,
 		Fees: FeeConfig{
-			InitialGasPrice: big.NewInt(2),
-			MinGasPrice:     big.NewInt(1),
-			TxBankSendGas:   10,
+			InitialGasPrice:       big.NewInt(2),
+			MinDiscountedGasPrice: big.NewInt(1),
+			TxBankSendGas:         10,
 		},
 		FundedAccounts: []FundedAccount{{PublicKey: pubKey, Balances: "100test-token"}},
 		GenTxs:         []json.RawMessage{[]byte("tx1")},
@@ -243,12 +243,12 @@ func TestNetworkConfigNotMutable(t *testing.T) {
 	n1 := NewNetwork(cfg)
 
 	cfg.Fees.InitialGasPrice.Set(big.NewInt(150))
-	cfg.Fees.MinGasPrice.Set(big.NewInt(100))
+	cfg.Fees.MinDiscountedGasPrice.Set(big.NewInt(100))
 	cfg.FundedAccounts[0] = FundedAccount{PublicKey: pubKey, Balances: "100test-token2"}
 	cfg.GenTxs[0] = []byte("tx2")
 
 	assertT.Equal("2", n1.InitialGasPrice().String())
-	assertT.Equal("1", n1.MinGasPrice().String())
+	assertT.Equal("1", n1.MinDiscountedGasPrice().String())
 	assertT.EqualValues(n1.fundedAccounts[0], FundedAccount{PublicKey: pubKey, Balances: "100test-token"})
 	assertT.EqualValues(n1.genTxs[0], []byte("tx1"))
 }
@@ -262,19 +262,19 @@ func TestNetworkFeesNotMutable(t *testing.T) {
 		AddressPrefix: "core",
 		TokenSymbol:   TokenSymbolMain,
 		Fees: FeeConfig{
-			InitialGasPrice: big.NewInt(2),
-			MinGasPrice:     big.NewInt(1),
-			TxBankSendGas:   10,
+			InitialGasPrice:       big.NewInt(2),
+			MinDiscountedGasPrice: big.NewInt(1),
+			TxBankSendGas:         10,
 		},
 	}
 
 	n1 := NewNetwork(cfg)
 
 	n1.InitialGasPrice().Set(big.NewInt(150))
-	n1.MinGasPrice().Set(big.NewInt(100))
+	n1.MinDiscountedGasPrice().Set(big.NewInt(100))
 
 	assertT.Equal("2", n1.InitialGasPrice().String())
-	assertT.Equal("1", n1.MinGasPrice().String())
+	assertT.Equal("1", n1.MinDiscountedGasPrice().String())
 }
 
 func TestNetworkConfigConditions(t *testing.T) {
@@ -282,10 +282,10 @@ func TestNetworkConfigConditions(t *testing.T) {
 	assertT := assert.New(t)
 	for _, cfg := range networks {
 		requireT.NotNil(cfg.Fees.InitialGasPrice)
-		requireT.NotNil(cfg.Fees.MinGasPrice)
+		requireT.NotNil(cfg.Fees.MinDiscountedGasPrice)
 		assertT.True(cfg.Fees.InitialGasPrice.Sign() == 1)
-		assertT.True(cfg.Fees.MinGasPrice.Sign() == 1)
-		assertT.True(cfg.Fees.InitialGasPrice.Cmp(cfg.Fees.MinGasPrice) >= 0)
+		assertT.True(cfg.Fees.MinDiscountedGasPrice.Sign() == 1)
+		assertT.True(cfg.Fees.InitialGasPrice.Cmp(cfg.Fees.MinDiscountedGasPrice) >= 0)
 
 		assertT.Greater(cfg.Fees.TxBankSendGas, uint64(0))
 	}

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -10,13 +10,9 @@ import (
 )
 
 func main() {
-	network, err := app.NetworkByChainID(app.Mainnet)
-	if err != nil {
-		panic(err)
-	}
 	rootCmd, _ := cosmoscmd.NewRootCmd(
 		app.Name,
-		network.AddressPrefix(),
+		app.DefaultNetwork.AddressPrefix(),
 		app.DefaultNodeHome,
 		app.Name,
 		app.ModuleBasics,

--- a/x/auth/ante/ante.go
+++ b/x/auth/ante/ante.go
@@ -1,0 +1,58 @@
+package ante
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	"github.com/cosmos/cosmos-sdk/x/auth/types"
+)
+
+// HandlerOptions are the options required for constructing a default SDK AnteHandler.
+type HandlerOptions struct {
+	AccountKeeper   AccountKeeper
+	BankKeeper      types.BankKeeper
+	FeegrantKeeper  FeegrantKeeper
+	SignModeHandler authsigning.SignModeHandler
+	SigGasConsumer  func(meter sdk.GasMeter, sig signing.SignatureV2, params types.Params) error
+}
+
+// NewAnteHandler returns an AnteHandler that checks and increments sequence
+// numbers, checks signatures & account numbers, and deducts fees from the first
+// signer.
+func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
+	if options.AccountKeeper == nil {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "account keeper is required for ante builder")
+	}
+
+	if options.BankKeeper == nil {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "bank keeper is required for ante builder")
+	}
+
+	if options.SignModeHandler == nil {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "sign mode handler is required for ante builder")
+	}
+
+	var sigGasConsumer = options.SigGasConsumer
+	if sigGasConsumer == nil {
+		sigGasConsumer = DefaultSigVerificationGasConsumer
+	}
+
+	anteDecorators := []sdk.AnteDecorator{
+		NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
+		NewRejectExtensionOptionsDecorator(),
+		NewMempoolFeeDecorator(),
+		NewValidateBasicDecorator(),
+		NewTxTimeoutHeightDecorator(),
+		NewValidateMemoDecorator(options.AccountKeeper),
+		NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
+		NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper),
+		NewSetPubKeyDecorator(options.AccountKeeper), // SetPubKeyDecorator must be called before all signature verification decorators
+		NewValidateSigCountDecorator(options.AccountKeeper),
+		NewSigGasConsumeDecorator(options.AccountKeeper, sigGasConsumer),
+		NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
+		NewIncrementSequenceDecorator(options.AccountKeeper),
+	}
+
+	return sdk.ChainAnteDecorators(anteDecorators...), nil
+}

--- a/x/auth/ante/ante.go
+++ b/x/auth/ante/ante.go
@@ -42,7 +42,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 	anteDecorators := []sdk.AnteDecorator{
 		authante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
 		authante.NewRejectExtensionOptionsDecorator(),
-		authante.NewMempoolFeeDecorator(),
+		NewMempoolFeeDecorator(),
 		authante.NewValidateBasicDecorator(),
 		authante.NewTxTimeoutHeightDecorator(),
 		authante.NewValidateMemoDecorator(options.AccountKeeper),

--- a/x/auth/ante/ante.go
+++ b/x/auth/ante/ante.go
@@ -4,15 +4,16 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
 // HandlerOptions are the options required for constructing a default SDK AnteHandler.
 type HandlerOptions struct {
-	AccountKeeper   AccountKeeper
+	AccountKeeper   authante.AccountKeeper
 	BankKeeper      types.BankKeeper
-	FeegrantKeeper  FeegrantKeeper
+	FeegrantKeeper  authante.FeegrantKeeper
 	SignModeHandler authsigning.SignModeHandler
 	SigGasConsumer  func(meter sdk.GasMeter, sig signing.SignatureV2, params types.Params) error
 }
@@ -35,23 +36,23 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 
 	var sigGasConsumer = options.SigGasConsumer
 	if sigGasConsumer == nil {
-		sigGasConsumer = DefaultSigVerificationGasConsumer
+		sigGasConsumer = authante.DefaultSigVerificationGasConsumer
 	}
 
 	anteDecorators := []sdk.AnteDecorator{
-		NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
-		NewRejectExtensionOptionsDecorator(),
-		NewMempoolFeeDecorator(),
-		NewValidateBasicDecorator(),
-		NewTxTimeoutHeightDecorator(),
-		NewValidateMemoDecorator(options.AccountKeeper),
-		NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
-		NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper),
-		NewSetPubKeyDecorator(options.AccountKeeper), // SetPubKeyDecorator must be called before all signature verification decorators
-		NewValidateSigCountDecorator(options.AccountKeeper),
-		NewSigGasConsumeDecorator(options.AccountKeeper, sigGasConsumer),
-		NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
-		NewIncrementSequenceDecorator(options.AccountKeeper),
+		authante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
+		authante.NewRejectExtensionOptionsDecorator(),
+		authante.NewMempoolFeeDecorator(),
+		authante.NewValidateBasicDecorator(),
+		authante.NewTxTimeoutHeightDecorator(),
+		authante.NewValidateMemoDecorator(options.AccountKeeper),
+		authante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
+		authante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper),
+		authante.NewSetPubKeyDecorator(options.AccountKeeper), // SetPubKeyDecorator must be called before all signature verification decorators
+		authante.NewValidateSigCountDecorator(options.AccountKeeper),
+		authante.NewSigGasConsumeDecorator(options.AccountKeeper, sigGasConsumer),
+		authante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
+		authante.NewIncrementSequenceDecorator(options.AccountKeeper),
 	}
 
 	return sdk.ChainAnteDecorators(anteDecorators...), nil

--- a/x/auth/ante/ante.go
+++ b/x/auth/ante/ante.go
@@ -1,3 +1,6 @@
+// This content was copied and modified based on github.com/cosmos/cosmos-sdk/x/auth/ante/ante.go
+// Original content: https://github.com/cosmos/cosmos-sdk/blob/ad9e5620fb3445c716e9de45cfcdb56e8f1745bf/x/auth/ante/ante.go
+
 package ante
 
 import (

--- a/x/auth/ante/fee.go
+++ b/x/auth/ante/fee.go
@@ -1,3 +1,6 @@
+// This content was copied and modified based on github.com/cosmos/cosmos-sdk/x/auth/ante/fee.go
+// Original content: https://github.com/cosmos/cosmos-sdk/blob/ad9e5620fb3445c716e9de45cfcdb56e8f1745bf/x/auth/ante/fee.go
+
 package ante
 
 import (

--- a/x/auth/ante/fee.go
+++ b/x/auth/ante/fee.go
@@ -15,12 +15,14 @@ type MempoolFeeDecorator struct {
 	minGasPrice sdk.Coin
 }
 
+// NewMempoolFeeDecorator creates ante decorator refusing transactions which does not offer minimum gas price
 func NewMempoolFeeDecorator(minGasPrice sdk.Coin) MempoolFeeDecorator {
 	return MempoolFeeDecorator{
 		minGasPrice: minGasPrice,
 	}
 }
 
+// AnteHandle handles transaction in ante decorator
 func (mfd MempoolFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
 	feeTx, ok := tx.(sdk.FeeTx)
 	if !ok {

--- a/x/auth/ante/fee.go
+++ b/x/auth/ante/fee.go
@@ -1,0 +1,52 @@
+package ante
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+// MempoolFeeDecorator will check if the transaction's fee is at least as large
+// as the local validator's minimum gasFee (defined in validator config).
+// If fee is too low, decorator returns error and tx is rejected from mempool.
+// Note this only applies when ctx.CheckTx = true
+// If fee is high enough or not CheckTx, then call next AnteHandler
+// CONTRACT: Tx must implement FeeTx to use MempoolFeeDecorator
+type MempoolFeeDecorator struct{}
+
+func NewMempoolFeeDecorator() MempoolFeeDecorator {
+	return MempoolFeeDecorator{}
+}
+
+func (mfd MempoolFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	feeTx, ok := tx.(sdk.FeeTx)
+	if !ok {
+		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "Tx must be a FeeTx")
+	}
+
+	feeCoins := feeTx.GetFee()
+	gas := feeTx.GetGas()
+
+	// Ensure that the provided fees meet a minimum threshold for the validator,
+	// if this is a CheckTx. This is only for local mempool purposes, and thus
+	// is only ran on check tx.
+	if ctx.IsCheckTx() && !simulate {
+		minGasPrices := ctx.MinGasPrices()
+		if !minGasPrices.IsZero() {
+			requiredFees := make(sdk.Coins, len(minGasPrices))
+
+			// Determine the required fees by multiplying each required minimum gas
+			// price by the gas limit, where fee = ceil(minGasPrice * gasLimit).
+			glDec := sdk.NewDec(int64(gas))
+			for i, gp := range minGasPrices {
+				fee := gp.Amount.Mul(glDec)
+				requiredFees[i] = sdk.NewCoin(gp.Denom, fee.Ceil().RoundInt())
+			}
+
+			if !feeCoins.IsAnyGTE(requiredFees) {
+				return ctx, sdkerrors.Wrapf(sdkerrors.ErrInsufficientFee, "insufficient fees; got: %s required: %s", feeCoins, requiredFees)
+			}
+		}
+	}
+
+	return next(ctx, tx, simulate)
+}


### PR DESCRIPTION
By default, in cosmos sdk, each node independently define the minimum gas price for accepted transactions.
In this PR per-network, node-independent, global minimum gas price is introduced by modifying ante handler.

- standard ante handler contains `MempoolFeeDecorator` decorator which is responsible for checking if fee provided with transaction is above the level required by the node
- in this PR ante handler constructor and `MempoolFeeDecorator` are copied
- `MempoolFeeDecorator` is reimplemented (`x/auth/ante/fee.go`) to check if fee provided by transaction meets requirement defined by network
- ante handler constructor (`x/auth/ante/ante.go`) is adjusted to inject the modified decorator instead of the default one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coreumfoundation/coreum/109)
<!-- Reviewable:end -->
