### PR TITLE
We require go 1.17 to build `crust`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Everyone is encouraged to run a chain locally for development and testing purpos
 
 Entire process of running local chain is automated by our tooling. The only prerequisites are:
 - `docker` and `tmux` installed from your favorite package manager
-- `go 1.16` or newer installed and available in your `PATH`
+- `go 1.17` or newer installed and available in your `PATH`
 
 ### Build binaries
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coreumfoundation/coreum/136)
<!-- Reviewable:end -->
