### PR TITLE
Reintroduce test disabled earlier due to transition period caused by introduction of `feemodel`

### DIFF
--- a/integration-tests/index.go
+++ b/integration-tests/index.go
@@ -13,9 +13,7 @@ func Tests() testing.TestSet {
 			auth.TestUnexpectedSequenceNumber,
 			auth.TestTooLowGasPrice,
 			auth.TestNoFee,
-			// FIXME (wojtek): This test might be enabled once crust imports new version of coreum containing feemodel
-			// because only then MaxBlockGas is set in genesis.json when znet creates blockchain
-			// auth.TestGasLimitHigherThanMaxBlockGas,
+			auth.TestGasLimitHigherThanMaxBlockGas,
 			auth.TestGasLimitEqualToMaxBlockGas,
 			bank.TestInitialBalance,
 			bank.TestCoreTransfer,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coreumfoundation/coreum/147)
<!-- Reviewable:end -->
