### PR TITLE
added tag to ignore markdown-link-check

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,4 +1,5 @@
 <!-- This file is auto-generated. Please do not modify it yourself. -->
+<!-- markdown-link-check-disable -->
 # Protobuf Documentation
 <a name="top"></a>
 
@@ -15670,3 +15671,5 @@ ContractCodeHistoryOperationType actions that caused a code change
 | <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode | string | string | string | String (UTF-8) |
 | <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str | []byte | ByteString | string | String (ASCII-8BIT) |
 
+
+<!-- markdown-link-check-enable -->

--- a/docs/protodoc-markdown.tmpl
+++ b/docs/protodoc-markdown.tmpl
@@ -1,4 +1,5 @@
 <!-- This file is auto-generated. Please do not modify it yourself. -->
+<!-- markdown-link-check-disable -->
 # Protobuf Documentation
 <a name="top"></a>
 
@@ -103,3 +104,5 @@
 {{range .Scalars -}}
   | <a name="{{.ProtoType}}" /> {{.ProtoType}} | {{.Notes}} | {{.CppType}} | {{.JavaType}} | {{.PythonType}} | {{.GoType}} | {{.CSharp}} | {{.PhpType}} | {{.RubyType}} |
 {{end}}
+
+<!-- markdown-link-check-enable -->


### PR DESCRIPTION
To pass the docs markdown link check we should change links that brakes compatibility with the Coreum repo.
The solution is adding tags which will put api.md file to ignore for markdown-link-check in docs repo.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/coreum/538)
<!-- Reviewable:end -->
