### PR TITLE
Improve integration tests timeouts to work with fast block time.

### DIFF
--- a/integration-tests/chain_ibc.go
+++ b/integration-tests/chain_ibc.go
@@ -122,7 +122,7 @@ func (c ChainContext) AwaitForBalance(
 	bankClient := banktypes.NewQueryClient(c.ClientContext)
 	retryCtx, retryCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer retryCancel()
-	err := retry.Do(retryCtx, time.Second, func() error {
+	err := retry.Do(retryCtx, 100*time.Millisecond, func() error {
 		requestCtx, requestCancel := context.WithTimeout(retryCtx, 5*time.Second)
 		defer requestCancel()
 
@@ -159,7 +159,7 @@ func (c ChainContext) AwaitForIBCChannelID(ctx context.Context, t *testing.T, po
 	ibcChannelClient := ibcchanneltypes.NewQueryClient(c.ClientContext)
 
 	var channelID string
-	require.NoError(t, retry.Do(retryCtx, time.Second, func() error {
+	require.NoError(t, retry.Do(retryCtx, 500*time.Millisecond, func() error {
 		requestCtx, requestCancel := context.WithTimeout(ctx, 5*time.Second)
 		defer requestCancel()
 
@@ -241,7 +241,7 @@ func (c ChainContext) AwaitForIBCClientAndConnectionIDs(ctx context.Context, t *
 		err                    error
 	)
 
-	require.NoError(t, retry.Do(retryCtx, time.Second, func() error {
+	require.NoError(t, retry.Do(retryCtx, 500*time.Millisecond, func() error {
 		clientID, connectionID, err = c.getIBCClientAndConnectionIDs(retryCtx, peerChainID)
 		if err != nil {
 			return retry.Retryable(errors.Errorf("client and connection are not ready yet, %s", err))

--- a/integration-tests/ibc/transfer_test.go
+++ b/integration-tests/ibc/transfer_test.go
@@ -133,9 +133,9 @@ func TestTimedOutTransfer(t *testing.T) {
 	ctx, chains := integrationtests.NewChainsTestingContext(t)
 	requireT := require.New(t)
 	coreumChain := chains.Coreum
-	gaiaChain := chains.Osmosis
+	osmosisChain := chains.Osmosis
 
-	gaiaToCoreumChannelID := gaiaChain.AwaitForIBCChannelID(ctx, t, ibctransfertypes.PortID, coreumChain.ChainSettings.ChainID)
+	gaiaToCoreumChannelID := osmosisChain.AwaitForIBCChannelID(ctx, t, ibctransfertypes.PortID, coreumChain.ChainSettings.ChainID)
 
 	retryCtx, retryCancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer retryCancel()
@@ -147,7 +147,7 @@ func TestTimedOutTransfer(t *testing.T) {
 	// we must retry. Otherwise, if tokens were returned back to the sender, we might continue the test.
 	err := retry.Do(retryCtx, time.Millisecond, func() error {
 		coreumSender := coreumChain.GenAccount()
-		gaiaRecipient := gaiaChain.GenAccount()
+		gaiaRecipient := osmosisChain.GenAccount()
 
 		sendToGaiaCoin := coreumChain.NewCoin(sdk.NewInt(1000))
 		coreumChain.FundAccountWithOptions(ctx, t, coreumSender, integrationtests.BalancesOptions{
@@ -155,7 +155,7 @@ func TestTimedOutTransfer(t *testing.T) {
 			Amount:   sendToGaiaCoin.Amount,
 		})
 
-		_, err := coreumChain.ExecuteTimingOutIBCTransfer(ctx, t, coreumSender, sendToGaiaCoin, gaiaChain.ChainContext, gaiaRecipient)
+		_, err := coreumChain.ExecuteTimingOutIBCTransfer(ctx, t, coreumSender, sendToGaiaCoin, osmosisChain.ChainContext, gaiaRecipient)
 		switch {
 		case err == nil:
 		case strings.Contains(err.Error(), ibcchanneltypes.ErrPacketTimeout.Error()):
@@ -185,7 +185,7 @@ func TestTimedOutTransfer(t *testing.T) {
 			// In this goroutine we check if funds were delivered to the other chain.
 			// If this happens it means timeout didn't occur and we must try again.
 
-			if err := gaiaChain.AwaitForBalance(parallelCtx, t, gaiaRecipient, sdk.NewCoin(convertToIBCDenom(gaiaToCoreumChannelID, sendToGaiaCoin.Denom), sendToGaiaCoin.Amount)); err == nil {
+			if err := osmosisChain.AwaitForBalance(parallelCtx, t, gaiaRecipient, sdk.NewCoin(convertToIBCDenom(gaiaToCoreumChannelID, sendToGaiaCoin.Denom), sendToGaiaCoin.Amount)); err == nil {
 				select {
 				case errCh <- retry.Retryable(errors.New("timeout didn't happen")):
 					parallelCancel()
@@ -206,9 +206,9 @@ func TestTimedOutTransfer(t *testing.T) {
 		// At this point we are sure that timeout happened.
 
 		// funds should not be received on gaia
-		bankClient := banktypes.NewQueryClient(gaiaChain.ClientContext)
+		bankClient := banktypes.NewQueryClient(osmosisChain.ClientContext)
 		resp, err := bankClient.Balance(ctx, &banktypes.QueryBalanceRequest{
-			Address: gaiaChain.ConvertToBech32Address(gaiaRecipient),
+			Address: osmosisChain.ConvertToBech32Address(gaiaRecipient),
 			Denom:   convertToIBCDenom(gaiaToCoreumChannelID, sendToGaiaCoin.Denom),
 		})
 		requireT.NoError(err)

--- a/integration-tests/ibc/transfer_test.go
+++ b/integration-tests/ibc/transfer_test.go
@@ -135,7 +135,7 @@ func TestTimedOutTransfer(t *testing.T) {
 	coreumChain := chains.Coreum
 	osmosisChain := chains.Osmosis
 
-	gaiaToCoreumChannelID := osmosisChain.AwaitForIBCChannelID(ctx, t, ibctransfertypes.PortID, coreumChain.ChainSettings.ChainID)
+	osmosisToCoreumChannelID := osmosisChain.AwaitForIBCChannelID(ctx, t, ibctransfertypes.PortID, coreumChain.ChainSettings.ChainID)
 
 	retryCtx, retryCancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer retryCancel()
@@ -185,7 +185,7 @@ func TestTimedOutTransfer(t *testing.T) {
 			// In this goroutine we check if funds were delivered to the other chain.
 			// If this happens it means timeout didn't occur and we must try again.
 
-			if err := osmosisChain.AwaitForBalance(parallelCtx, t, gaiaRecipient, sdk.NewCoin(convertToIBCDenom(gaiaToCoreumChannelID, sendToGaiaCoin.Denom), sendToGaiaCoin.Amount)); err == nil {
+			if err := osmosisChain.AwaitForBalance(parallelCtx, t, gaiaRecipient, sdk.NewCoin(convertToIBCDenom(osmosisToCoreumChannelID, sendToGaiaCoin.Denom), sendToGaiaCoin.Amount)); err == nil {
 				select {
 				case errCh <- retry.Retryable(errors.New("timeout didn't happen")):
 					parallelCancel()
@@ -209,7 +209,7 @@ func TestTimedOutTransfer(t *testing.T) {
 		bankClient := banktypes.NewQueryClient(osmosisChain.ClientContext)
 		resp, err := bankClient.Balance(ctx, &banktypes.QueryBalanceRequest{
 			Address: osmosisChain.ConvertToBech32Address(gaiaRecipient),
-			Denom:   convertToIBCDenom(gaiaToCoreumChannelID, sendToGaiaCoin.Denom),
+			Denom:   convertToIBCDenom(osmosisToCoreumChannelID, sendToGaiaCoin.Denom),
 		})
 		requireT.NoError(err)
 		requireT.Equal("0", resp.Balance.Amount.String())

--- a/integration-tests/init.go
+++ b/integration-tests/init.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"testing"
+	"time"
 
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
@@ -98,7 +99,7 @@ func init() { //nolint:funlen // will be shortened after the crust merge
 		}
 	}
 
-	queryCtx, queryCtxCancel := context.WithTimeout(ctx, client.DefaultContextConfig().TimeoutConfig.RequestTimeout)
+	queryCtx, queryCtxCancel := context.WithTimeout(ctx, getTestContextConfig().TimeoutConfig.RequestTimeout)
 	defer queryCtxCancel()
 
 	// ********** Coreum **********
@@ -109,7 +110,7 @@ func init() { //nolint:funlen // will be shortened after the crust merge
 	}
 	coreumSettings := queryCommonSettings(queryCtx, coreumGRPCClient)
 
-	coreumClientCtx := client.NewContext(client.DefaultContextConfig(), app.ModuleBasics).
+	coreumClientCtx := client.NewContext(getTestContextConfig(), app.ModuleBasics).
 		WithGRPCClient(coreumGRPCClient)
 
 	coreumFeemodelParamsRes, err := feemodeltypes.NewQueryClient(coreumClientCtx).Params(queryCtx, &feemodeltypes.QueryParamsRequest{})
@@ -205,7 +206,7 @@ func NewChainsTestingContext(t *testing.T) (context.Context, Chains) {
 }
 
 func queryCommonSettings(ctx context.Context, grpcClient protobufgrpc.ClientConn) ChainSettings {
-	clientCtx := client.NewContext(client.DefaultContextConfig(), app.ModuleBasics).
+	clientCtx := client.NewContext(getTestContextConfig(), app.ModuleBasics).
 		WithGRPCClient(grpcClient)
 
 	infoBeforeRes, err := tmservice.NewServiceClient(clientCtx).GetNodeInfo(ctx, &tmservice.GetNodeInfoRequest{})
@@ -251,4 +252,11 @@ func queryCommonSettings(ctx context.Context, grpcClient protobufgrpc.ClientConn
 		Denom:         denom,
 		AddressPrefix: addressPrefix,
 	}
+}
+
+func getTestContextConfig() client.ContextConfig {
+	cfg := client.DefaultContextConfig()
+	cfg.TimeoutConfig.TxStatusPollInterval = 100 * time.Millisecond
+
+	return cfg
 }


### PR DESCRIPTION
# Description

The current integration tests' timeout is set with the expectation that the coreum block time and IBC chains block time are slower than 1 sec. So when we run them against the zent with faster block time, for example, 0.5sec, they pass with the time more than they can. Hence to improve it we can update the retry timeouts we use.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/coreum/579)
<!-- Reviewable:end -->
