### PR TITLE
Move duplicated `getIssueFee` & `getMintFee` helpers to `CoreumChain` in integr-tests

### DIFF
--- a/integration-tests/coreum.go
+++ b/integration-tests/coreum.go
@@ -183,6 +183,8 @@ func (c CoreumChain) CreateValidator(ctx context.Context, t *testing.T, stakingA
 
 // QueryAssetFTParams queries for asset/ft module params and returns them.
 func (c CoreumChain) QueryAssetFTParams(ctx context.Context, t *testing.T) assetfttypes.Params {
+	t.Helper()
+
 	queryClient := assetfttypes.NewQueryClient(c.ClientContext)
 	resp, err := queryClient.Params(ctx, &assetfttypes.QueryParamsRequest{})
 	require.NoError(t, err)
@@ -192,6 +194,8 @@ func (c CoreumChain) QueryAssetFTParams(ctx context.Context, t *testing.T) asset
 
 // QueryAssetNFTParams queries for asset/nft module params and returns them.
 func (c CoreumChain) QueryAssetNFTParams(ctx context.Context, t *testing.T) assetnfttypes.Params {
+	t.Helper()
+
 	queryClient := assetnfttypes.NewQueryClient(c.ClientContext)
 	resp, err := queryClient.Params(ctx, &assetnfttypes.QueryParamsRequest{})
 	require.NoError(t, err)

--- a/integration-tests/coreum.go
+++ b/integration-tests/coreum.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/CoreumFoundation/coreum/v2/pkg/client"
+	assetfttypes "github.com/CoreumFoundation/coreum/v2/x/asset/ft/types"
+	assetnfttypes "github.com/CoreumFoundation/coreum/v2/x/asset/nft/types"
 	"github.com/CoreumFoundation/coreum/v2/x/deterministicgas"
 )
 
@@ -177,4 +179,22 @@ func (c CoreumChain) CreateValidator(ctx context.Context, t *testing.T, stakingA
 			t.Fatalf("unexpected validator %q status after removal: %s", validatorAddr, resp.Validator.Status)
 		}
 	}, nil
+}
+
+// QueryAssetFTParams queries for asset/ft module params and returns them.
+func (c CoreumChain) QueryAssetFTParams(ctx context.Context, t *testing.T) assetfttypes.Params {
+	queryClient := assetfttypes.NewQueryClient(c.ClientContext)
+	resp, err := queryClient.Params(ctx, &assetfttypes.QueryParamsRequest{})
+	require.NoError(t, err)
+
+	return resp.Params
+}
+
+// QueryAssetNFTParams queries for asset/nft module params and returns them.
+func (c CoreumChain) QueryAssetNFTParams(ctx context.Context, t *testing.T) assetnfttypes.Params {
+	queryClient := assetnfttypes.NewQueryClient(c.ClientContext)
+	resp, err := queryClient.Params(ctx, &assetnfttypes.QueryParamsRequest{})
+	require.NoError(t, err)
+
+	return resp.Params
 }

--- a/integration-tests/ibc/asset_ft_test.go
+++ b/integration-tests/ibc/asset_ft_test.go
@@ -34,7 +34,7 @@ func TestIBCFailsIfNotEnabled(t *testing.T) {
 	coreumChain := chains.Coreum
 	coreumIssuer := coreumChain.GenAccount()
 
-	issueFee := getIssueFee(ctx, t, coreumChain.ClientContext).Amount
+	issueFee := coreumChain.QueryAssetFTParams(ctx, t).IssueFee.Amount
 	coreumChain.FundAccountWithOptions(ctx, t, coreumIssuer, integrationtests.BalancesOptions{
 		Messages: []sdk.Msg{
 			&assetfttypes.MsgIssue{},
@@ -111,7 +111,7 @@ func TestIBCAssetFTSendCommissionAndBurnRate(t *testing.T) {
 	})
 
 	coreumIssuer := coreumChain.GenAccount()
-	issueFee := getIssueFee(ctx, t, coreumChain.ClientContext).Amount
+	issueFee := coreumChain.QueryAssetFTParams(ctx, t).IssueFee.Amount
 	coreumChain.FundAccountWithOptions(ctx, t, coreumIssuer, integrationtests.BalancesOptions{
 		Messages: []sdk.Msg{
 			&banktypes.MsgSend{},
@@ -355,7 +355,7 @@ func TestIBCAssetFTWhitelisting(t *testing.T) {
 		Amount:  gaiaChain.NewCoin(sdk.NewInt(1000000)), // coin for the fees
 	})
 
-	issueFee := getIssueFee(ctx, t, coreumChain.ClientContext).Amount
+	issueFee := coreumChain.QueryAssetFTParams(ctx, t).IssueFee.Amount
 	coreumChain.FundAccountWithOptions(ctx, t, coreumIssuer, integrationtests.BalancesOptions{
 		Messages: []sdk.Msg{
 			&assetfttypes.MsgIssue{},
@@ -450,7 +450,7 @@ func TestIBCAssetFTFreezing(t *testing.T) {
 		Amount:  gaiaChain.NewCoin(sdk.NewInt(1000000)), // coin for the fees
 	})
 
-	issueFee := getIssueFee(ctx, t, coreumChain.ClientContext).Amount
+	issueFee := coreumChain.QueryAssetFTParams(ctx, t).IssueFee.Amount
 	coreumChain.FundAccountWithOptions(ctx, t, coreumIssuer, integrationtests.BalancesOptions{
 		Messages: []sdk.Msg{
 			&assetfttypes.MsgIssue{},
@@ -550,7 +550,7 @@ func TestEscrowAddressIsResistantToFreezingAndWhitelisting(t *testing.T) {
 		Amount:  gaiaChain.NewCoin(sdk.NewInt(1000000)), // coin for the fees
 	})
 
-	issueFee := getIssueFee(ctx, t, coreumChain.ClientContext).Amount
+	issueFee := coreumChain.QueryAssetFTParams(ctx, t).IssueFee.Amount
 	coreumChain.FundAccountWithOptions(ctx, t, coreumIssuer, integrationtests.BalancesOptions{
 		Messages: []sdk.Msg{
 			&assetfttypes.MsgIssue{},
@@ -634,7 +634,7 @@ func TestIBCGlobalFreeze(t *testing.T) {
 		Amount:  gaiaChain.NewCoin(sdk.NewInt(1000000)), // coin for the fees
 	})
 
-	issueFee := getIssueFee(ctx, t, coreumChain.ClientContext).Amount
+	issueFee := coreumChain.QueryAssetFTParams(ctx, t).IssueFee.Amount
 	coreumChain.FundAccountWithOptions(ctx, t, coreumIssuer, integrationtests.BalancesOptions{
 		Messages: []sdk.Msg{
 			&assetfttypes.MsgIssue{},
@@ -778,7 +778,7 @@ func TestIBCAssetFTTimedOutTransfer(t *testing.T) {
 	// On every trial we send funds from one chain to the other. Then we observe accounts on both chains
 	// to find if IBC transfer completed successfully or timed out. If tokens were delivered to the recipient
 	// we must retry. Otherwise, if tokens were returned back to the sender, we might continue the test.
-	issueFee := getIssueFee(ctx, t, coreumChain.ClientContext).Amount
+	issueFee := coreumChain.QueryAssetFTParams(ctx, t).IssueFee.Amount
 	err := retry.Do(retryCtx, time.Millisecond, func() error {
 		coreumSender := coreumChain.GenAccount()
 		gaiaRecipient := gaiaChain.GenAccount()
@@ -897,7 +897,7 @@ func TestIBCAssetFTRejectedTransfer(t *testing.T) {
 			&ibctransfertypes.MsgTransfer{},
 			&ibctransfertypes.MsgTransfer{},
 		},
-		Amount: getIssueFee(ctx, t, coreumChain.ClientContext).Amount,
+		Amount: coreumChain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 	gaiaChain.Faucet.FundAccounts(ctx, t, integrationtests.FundedAccount{
 		Address: gaiaRecipient,
@@ -983,7 +983,7 @@ func TestIBCRejectedTransferWithWhitelistingAndFreezing(t *testing.T) {
 	// this type of IBC transfer is rejected by the receiving chain.
 	moduleAddress := authtypes.NewModuleAddress(ibctransfertypes.ModuleName)
 
-	issueFee := getIssueFee(ctx, t, coreumChain.ClientContext).Amount
+	issueFee := coreumChain.QueryAssetFTParams(ctx, t).IssueFee.Amount
 	coreumChain.FundAccountWithOptions(ctx, t, coreumIssuer, integrationtests.BalancesOptions{
 		Messages: []sdk.Msg{
 			&assetfttypes.MsgIssue{},
@@ -1109,7 +1109,7 @@ func TestIBCTimedOutTransferWithWhitelistingAndFreezing(t *testing.T) {
 	// On every trial we send funds from one chain to the other. Then we observe accounts on both chains
 	// to find if IBC transfer completed successfully or timed out. If tokens were delivered to the recipient
 	// we must retry. Otherwise, if tokens were returned back to the sender, we might continue the test.
-	issueFee := getIssueFee(ctx, t, coreumChain.ClientContext).Amount
+	issueFee := coreumChain.QueryAssetFTParams(ctx, t).IssueFee.Amount
 	err := retry.Do(retryCtx, time.Millisecond, func() error {
 		coreumIssuer := coreumChain.GenAccount()
 		coreumSender := coreumChain.GenAccount()
@@ -1335,12 +1335,4 @@ func assertBalanceChanges(t *testing.T, expectedBalanceChanges, balancesBefore, 
 		actualBalanceChange := balancesAfter[addr].Sub(balancesBefore[addr])
 		requireT.Equal(expectedBalanceChange.String(), actualBalanceChange.String())
 	}
-}
-
-func getIssueFee(ctx context.Context, t *testing.T, clientCtx client.Context) sdk.Coin {
-	queryClient := assetfttypes.NewQueryClient(clientCtx)
-	resp, err := queryClient.Params(ctx, &assetfttypes.QueryParamsRequest{})
-	require.NoError(t, err)
-
-	return resp.Params.IssueFee
 }

--- a/integration-tests/modules/assetft_test.go
+++ b/integration-tests/modules/assetft_test.go
@@ -28,7 +28,7 @@ func TestAssetFTQueryParams(t *testing.T) {
 	t.Parallel()
 
 	ctx, chain := integrationtests.NewCoreumTestingContext(t)
-	issueFee := getIssueFee(ctx, t, chain.ClientContext)
+	issueFee := chain.QueryAssetFTParams(ctx, t).IssueFee
 
 	assert.True(t, issueFee.Amount.GT(sdk.ZeroInt()))
 	assert.Equal(t, chain.ChainSettings.Denom, issueFee.Denom)
@@ -47,7 +47,7 @@ func TestAssetFTIssue(t *testing.T) {
 		Messages: []sdk.Msg{
 			&assetfttypes.MsgIssue{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 
 	issueMsg := &assetfttypes.MsgIssue{
@@ -72,7 +72,7 @@ func TestAssetFTIssue(t *testing.T) {
 	// verify issue fee was burnt
 	burntStr, err := event.FindStringEventAttribute(res.Events, banktypes.EventTypeCoinBurn, sdk.AttributeKeyAmount)
 	requireT.NoError(err)
-	requireT.Equal(getIssueFee(ctx, t, chain.ClientContext).String(), burntStr)
+	requireT.Equal(chain.QueryAssetFTParams(ctx, t).IssueFee.String(), burntStr)
 
 	// check that balance is 0 meaning issue fee was taken
 
@@ -92,7 +92,7 @@ func TestAssetFTIssueFeeProposal(t *testing.T) {
 
 	ctx, chain := integrationtests.NewCoreumTestingContext(t)
 	requireT := require.New(t)
-	origIssueFee := getIssueFee(ctx, t, chain.ClientContext)
+	origIssueFee := chain.QueryAssetFTParams(ctx, t).IssueFee
 
 	chain.Governance.UpdateParams(ctx, t, "Propose changing IssueFee in the assetft module",
 		[]paramproposal.ParamChange{
@@ -145,7 +145,7 @@ func TestAssetIssueAndQueryTokens(t *testing.T) {
 
 	ftClient := assetfttypes.NewQueryClient(clientCtx)
 
-	issueFee := getIssueFee(ctx, t, chain.ClientContext).Amount
+	issueFee := chain.QueryAssetFTParams(ctx, t).IssueFee.Amount
 
 	issuer1 := chain.GenAccount()
 	chain.FundAccountWithOptions(ctx, t, issuer1, integrationtests.BalancesOptions{
@@ -220,7 +220,7 @@ func TestBalanceQuery(t *testing.T) {
 
 	assertT := assert.New(t)
 
-	issueFee := getIssueFee(ctx, t, chain.ClientContext).Amount
+	issueFee := chain.QueryAssetFTParams(ctx, t).IssueFee.Amount
 
 	issuer := chain.GenAccount()
 	recipient := chain.GenAccount()
@@ -354,7 +354,7 @@ func TestAssetFTMint(t *testing.T) {
 			&assetfttypes.MsgMint{},
 			&assetfttypes.MsgMint{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount.MulRaw(2),
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount.MulRaw(2),
 	})
 
 	chain.FundAccountWithOptions(ctx, t, randomAddress, integrationtests.BalancesOptions{
@@ -489,7 +489,7 @@ func TestAssetFTBurn(t *testing.T) {
 			&assetfttypes.MsgBurn{},
 			&assetfttypes.MsgBurn{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount.MulRaw(2),
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount.MulRaw(2),
 	})
 
 	chain.FundAccountWithOptions(ctx, t, recipient, integrationtests.BalancesOptions{
@@ -669,7 +669,7 @@ func TestAssetFTBurnRate(t *testing.T) {
 			&assetfttypes.MsgIssue{},
 			&banktypes.MsgSend{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 	chain.FundAccountWithOptions(ctx, t, recipient1, integrationtests.BalancesOptions{
 		Messages: []sdk.Msg{
@@ -816,7 +816,7 @@ func TestAssetFTSendCommissionRate(t *testing.T) {
 			&assetfttypes.MsgIssue{},
 			&banktypes.MsgSend{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 	chain.FundAccountWithOptions(ctx, t, recipient1, integrationtests.BalancesOptions{
 		Messages: []sdk.Msg{
@@ -971,7 +971,7 @@ func TestAssetFTFreeze(t *testing.T) {
 			&assetfttypes.MsgUnfreeze{},
 			&assetfttypes.MsgUnfreeze{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 	chain.FundAccountWithOptions(ctx, t, recipient, integrationtests.BalancesOptions{
 		Messages: []sdk.Msg{
@@ -1256,7 +1256,7 @@ func TestAssetFTFreezeUnfreezable(t *testing.T) {
 			&assetfttypes.MsgIssue{},
 			&assetfttypes.MsgFreeze{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 
 	// Issue an unfreezable fungible token
@@ -1310,7 +1310,7 @@ func TestAssetFTFreezeIssuerAccount(t *testing.T) {
 			&assetfttypes.MsgIssue{},
 			&assetfttypes.MsgFreeze{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 
 	// Issue an freezable fungible token
@@ -1368,7 +1368,7 @@ func TestAssetFTGloballyFreeze(t *testing.T) {
 			&assetfttypes.MsgGloballyUnfreeze{},
 			&banktypes.MsgSend{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 	chain.FundAccountWithOptions(ctx, t, recipient, integrationtests.BalancesOptions{
 		Messages: []sdk.Msg{
@@ -1531,7 +1531,7 @@ func TestAssetCommissionRateExceedFreeze(t *testing.T) {
 			&banktypes.MsgSend{},
 			&assetfttypes.MsgFreeze{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 	chain.FundAccountWithOptions(ctx, t, recipient, integrationtests.BalancesOptions{
 		Messages: []sdk.Msg{
@@ -1616,7 +1616,7 @@ func TestSendCoreTokenWithRestrictedToken(t *testing.T) {
 			&banktypes.MsgSend{},
 			&assetfttypes.MsgFreeze{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 	chain.FundAccountWithOptions(ctx, t, recipient, integrationtests.BalancesOptions{
 		Messages: []sdk.Msg{
@@ -1704,7 +1704,7 @@ func TestNotEnoughBalanceForBurnRate(t *testing.T) {
 			&assetfttypes.MsgIssue{},
 			&banktypes.MsgSend{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 	chain.FundAccountWithOptions(ctx, t, recipient, integrationtests.BalancesOptions{
 		Messages: []sdk.Msg{
@@ -1783,7 +1783,7 @@ func TestNotEnoughBalanceForCommissionRate(t *testing.T) {
 			&assetfttypes.MsgIssue{},
 			&banktypes.MsgSend{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 	chain.FundAccountWithOptions(ctx, t, recipient, integrationtests.BalancesOptions{
 		Messages: []sdk.Msg{
@@ -1875,7 +1875,7 @@ func TestAssetFTWhitelist(t *testing.T) {
 			&banktypes.MsgSend{},
 			&banktypes.MsgSend{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 	chain.FundAccountWithOptions(ctx, t, nonIssuer, integrationtests.BalancesOptions{
 		Messages: []sdk.Msg{
@@ -2148,7 +2148,7 @@ func TestAssetFTWhitelistUnwhitelistable(t *testing.T) {
 			&assetfttypes.MsgIssue{},
 			&assetfttypes.MsgSetWhitelistedLimit{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 
 	// Issue an unwhitelistable fungible token
@@ -2202,7 +2202,7 @@ func TestAssetFTWhitelistIssuerAccount(t *testing.T) {
 			&assetfttypes.MsgIssue{},
 			&assetfttypes.MsgSetWhitelistedLimit{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 
 	// Issue an whitelistable fungible token
@@ -2266,7 +2266,7 @@ func TestBareToken(t *testing.T) {
 			&assetfttypes.MsgGloballyFreeze{},
 			&assetfttypes.MsgSetWhitelistedLimit{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 	chain.FundAccountWithOptions(ctx, t, recipient, integrationtests.BalancesOptions{
 		Messages: []sdk.Msg{
@@ -2409,7 +2409,7 @@ func TestAuthzWithAssetFT(t *testing.T) {
 			&authztypes.MsgGrant{},
 			&authztypes.MsgGrant{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 
 	// mint and grant authorization
@@ -2515,7 +2515,7 @@ func TestAssetFT_RatesAreNotApplied_OnMinting(t *testing.T) {
 			&assetfttypes.MsgIssue{},
 			&assetfttypes.MsgMint{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 
 	// Issue a fungible token
@@ -2580,14 +2580,14 @@ func TestAssetFTBurnRate_SendCommissionRate_OnBurning(t *testing.T) {
 			&banktypes.MsgSend{},
 			&assetfttypes.MsgIssue{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 
 	chain.FundAccountWithOptions(ctx, t, recipient, integrationtests.BalancesOptions{
 		Messages: []sdk.Msg{
 			&assetfttypes.MsgBurn{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 
 	// Issue a fungible token
@@ -2679,7 +2679,7 @@ func TestAssetFTFreezeAndBurn(t *testing.T) {
 			&assetfttypes.MsgIssue{},
 			&assetfttypes.MsgFreeze{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 
 	chain.FundAccountWithOptions(ctx, t, recipient, integrationtests.BalancesOptions{
@@ -2687,7 +2687,7 @@ func TestAssetFTFreezeAndBurn(t *testing.T) {
 			&assetfttypes.MsgBurn{},
 			&assetfttypes.MsgBurn{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 
 	// Issue a fungible token
@@ -2811,7 +2811,7 @@ func TestAssetFTFreeze_WithRates(t *testing.T) {
 					&assetfttypes.MsgIssue{},
 					&assetfttypes.MsgFreeze{},
 				},
-				Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+				Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 			})
 
 			chain.FundAccountWithOptions(ctx, t, recipient1, integrationtests.BalancesOptions{
@@ -2819,7 +2819,7 @@ func TestAssetFTFreeze_WithRates(t *testing.T) {
 					&banktypes.MsgSend{},
 					&banktypes.MsgSend{},
 				},
-				Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+				Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 			})
 
 			// Issue a fungible token
@@ -2941,7 +2941,7 @@ func TestAssetFTAminoMultisig(t *testing.T) {
 			&assetfttypes.MsgIssue{},
 			&assetfttypes.MsgBurn{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 
 	// Issue a fungible token
@@ -3021,7 +3021,7 @@ func TestAssetFTAminoMultisigWithAuthz(t *testing.T) {
 			grantMsg,
 		},
 		// the fee will be charged from the granter
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 
 	_, err = chain.SignAndBroadcastMultisigTx(
@@ -3084,12 +3084,4 @@ func assertCoinDistribution(ctx context.Context, clientCtx client.Context, t *te
 	supply, err := bankClient.SupplyOf(ctx, &banktypes.QuerySupplyOfRequest{Denom: denom})
 	requireT.NoError(err)
 	requireT.EqualValues(sdk.NewCoin(denom, sdk.NewInt(total)).String(), supply.Amount.String())
-}
-
-func getIssueFee(ctx context.Context, t *testing.T, clientCtx client.Context) sdk.Coin {
-	queryClient := assetfttypes.NewQueryClient(clientCtx)
-	resp, err := queryClient.Params(ctx, &assetfttypes.QueryParamsRequest{})
-	require.NoError(t, err)
-
-	return resp.Params.IssueFee
 }

--- a/integration-tests/modules/assetnft_test.go
+++ b/integration-tests/modules/assetnft_test.go
@@ -4,7 +4,6 @@ package modules
 
 import (
 	"bytes"
-	"context"
 	"testing"
 	"time"
 
@@ -33,7 +32,7 @@ func TestAssetNFTQueryParams(t *testing.T) {
 	t.Parallel()
 
 	ctx, chain := integrationtests.NewCoreumTestingContext(t)
-	mintFee := getMintFee(ctx, t, chain.ClientContext)
+	mintFee := chain.QueryAssetNFTParams(ctx, t).MintFee
 
 	assert.Equal(t, chain.ChainSettings.Denom, mintFee.Denom)
 }
@@ -210,7 +209,7 @@ func TestAssetNFTMint(t *testing.T) {
 			&assetnfttypes.MsgMint{},
 			&nft.MsgSend{},
 		},
-		Amount: getMintFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetNFTParams(ctx, t).MintFee.Amount,
 	})
 
 	// issue new NFT class
@@ -386,7 +385,7 @@ func TestAssetNFTMintFeeProposal(t *testing.T) {
 
 	ctx, chain := integrationtests.NewCoreumTestingContext(t)
 	requireT := require.New(t)
-	origMintFee := getMintFee(ctx, t, chain.ClientContext)
+	origMintFee := chain.QueryAssetNFTParams(ctx, t).MintFee
 
 	chain.Governance.UpdateParams(ctx, t, "Propose changing MintFee in the assetnft module",
 		[]paramproposal.ParamChange{
@@ -635,7 +634,7 @@ func TestAssetNFTBurnFrozen(t *testing.T) {
 			&assetnfttypes.MsgFreeze{},
 			&assetnfttypes.MsgUnfreeze{},
 		},
-		Amount: getMintFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetNFTParams(ctx, t).MintFee.Amount,
 	})
 
 	chain.FundAccountWithOptions(ctx, t, recipient1, integrationtests.BalancesOptions{
@@ -777,7 +776,7 @@ func TestAssetNFTBurnFrozen_Issuer(t *testing.T) {
 			&assetnfttypes.MsgFreeze{},
 			&assetnfttypes.MsgBurn{},
 		},
-		Amount: getMintFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetNFTParams(ctx, t).MintFee.Amount,
 	})
 
 	// issue new NFT class
@@ -881,7 +880,7 @@ func TestAssetNFTFreeze(t *testing.T) {
 			&assetnfttypes.MsgFreeze{},
 			&assetnfttypes.MsgUnfreeze{},
 		},
-		Amount: getMintFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetNFTParams(ctx, t).MintFee.Amount,
 	})
 
 	chain.FundAccountWithOptions(ctx, t, recipient1, integrationtests.BalancesOptions{
@@ -1078,7 +1077,7 @@ func TestAssetNFTWhitelist(t *testing.T) {
 			&assetnfttypes.MsgRemoveFromWhitelist{},
 			&assetnfttypes.MsgAddToWhitelist{},
 		},
-		Amount: getMintFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetNFTParams(ctx, t).MintFee.Amount,
 	})
 
 	// issue new NFT class
@@ -1327,7 +1326,7 @@ func TestAssetNFTAuthZ(t *testing.T) {
 			&assetnfttypes.MsgMint{},
 			&authztypes.MsgGrant{},
 		},
-		Amount: getMintFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetNFTParams(ctx, t).MintFee.Amount,
 	})
 
 	// issue new NFT class
@@ -1378,7 +1377,7 @@ func TestAssetNFTAuthZ(t *testing.T) {
 		Messages: []sdk.Msg{
 			&execMsg,
 		},
-		Amount: getMintFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetNFTParams(ctx, t).MintFee.Amount,
 	})
 
 	_, err = client.BroadcastTx(
@@ -1421,7 +1420,7 @@ func TestAssetNFTAminoMultisig(t *testing.T) {
 			&assetnfttypes.MsgMint{},
 			&nft.MsgSend{},
 		},
-		Amount: getMintFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetNFTParams(ctx, t).MintFee.Amount,
 	})
 
 	// issue new NFT class
@@ -1482,12 +1481,4 @@ func TestAssetNFTAminoMultisig(t *testing.T) {
 		ClassId: classID,
 		Id:      nftID,
 	}, nftRes.Nft)
-}
-
-func getMintFee(ctx context.Context, t *testing.T, clientCtx client.Context) sdk.Coin {
-	queryClient := assetnfttypes.NewQueryClient(clientCtx)
-	resp, err := queryClient.Params(ctx, &assetnfttypes.QueryParamsRequest{})
-	require.NoError(t, err)
-
-	return resp.Params.MintFee
 }

--- a/integration-tests/modules/auth_test.go
+++ b/integration-tests/modules/auth_test.go
@@ -31,7 +31,7 @@ func TestAuthFeeLimits(t *testing.T) {
 			&assetfttypes.MsgIssue{},
 		},
 		NondeterministicMessagesGas: uint64(maxBlockGas) + 100,
-		Amount:                      getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount:                      chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 
 	msg := &banktypes.MsgSend{

--- a/integration-tests/modules/bank_test.go
+++ b/integration-tests/modules/bank_test.go
@@ -81,7 +81,7 @@ func TestBankMultiSendBatchOutputs(t *testing.T) {
 	chain.FundAccountWithOptions(ctx, t, issuer, integrationtests.BalancesOptions{
 		Messages:                    append([]sdk.Msg{issueMsg}, multiSendMsgs...),
 		NondeterministicMessagesGas: 10_000_000, // to cover extra bytes because of the message size
-		Amount:                      getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount:                      chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 
 	// issue fungible tokens
@@ -156,7 +156,7 @@ func TestBankSendBatchMsgs(t *testing.T) {
 	}
 	chain.FundAccountWithOptions(ctx, t, issuer, integrationtests.BalancesOptions{
 		Messages: fundMsgs,
-		Amount:   getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount:   chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 
 	// issue fungible tokens
@@ -281,7 +281,7 @@ func TestBankSendDeterministicGasManyCoins(t *testing.T) {
 		Messages: append([]sdk.Msg{&banktypes.MsgSend{
 			Amount: make(sdk.Coins, numOfTokens),
 		}}, issueMsgs...),
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount.MulRaw(numOfTokens),
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount.MulRaw(numOfTokens),
 	})
 
 	// Issue fungible tokens
@@ -429,7 +429,7 @@ func TestBankMultiSendDeterministicGasManyCoins(t *testing.T) {
 				},
 			},
 		}}, issueMsgs...),
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount.MulRaw(numOfTokens),
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount.MulRaw(numOfTokens),
 	})
 
 	// Issue fungible tokens
@@ -521,7 +521,7 @@ func TestBankMultiSend(t *testing.T) {
 				{Coins: make(sdk.Coins, 2)},
 			},
 		}}, issueMsgs...),
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount.MulRaw(int64(len(issueMsgs))),
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount.MulRaw(int64(len(issueMsgs))),
 	})
 
 	// Issue fungible tokens
@@ -680,7 +680,7 @@ func TestBankMultiSendFromMultipleAccounts(t *testing.T) {
 		},
 	}
 
-	issueFee := getIssueFee(ctx, t, chain.ClientContext).Amount
+	issueFee := chain.QueryAssetFTParams(ctx, t).IssueFee.Amount
 
 	// fund accounts
 	chain.FundAccountWithOptions(ctx, t, sender1, integrationtests.BalancesOptions{

--- a/integration-tests/modules/vesting_test.go
+++ b/integration-tests/modules/vesting_test.go
@@ -225,7 +225,7 @@ func TestVestingAccountWithFTInteraction(t *testing.T) {
 			&assetfttypes.MsgFreeze{},
 			&assetfttypes.MsgUnfreeze{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 
 	// issue a fungible token

--- a/integration-tests/modules/wasm_test.go
+++ b/integration-tests/modules/wasm_test.go
@@ -749,7 +749,7 @@ func TestWASMFungibleTokenInContract(t *testing.T) {
 		moduleswasm.FTWASM,
 		integrationtests.InstantiateConfig{
 			// we add the initial amount to let the contract issue the token on behalf of it
-			Amount:     getIssueFee(ctx, t, chain.ClientContext),
+			Amount:     chain.QueryAssetFTParams(ctx, t).IssueFee,
 			AccessType: wasmtypes.AccessTypeUnspecified,
 			Payload:    issuerFTInstantiatePayload,
 			Label:      "fungible_token",
@@ -977,7 +977,7 @@ func TestWASMFungibleTokenInContract(t *testing.T) {
 	var wasmParamsRes assetfttypes.QueryParamsResponse
 	requireT.NoError(json.Unmarshal(queryOut, &wasmParamsRes))
 	requireT.Equal(
-		getIssueFee(ctx, t, chain.ClientContext), wasmParamsRes.Params.IssueFee,
+		chain.QueryAssetFTParams(ctx, t).IssueFee, wasmParamsRes.Params.IssueFee,
 	)
 
 	// ********** Token **********
@@ -1364,7 +1364,7 @@ func TestWASMNonFungibleTokenInContract(t *testing.T) {
 	var wasmParamsRes assetnfttypes.QueryParamsResponse
 	requireT.NoError(json.Unmarshal(queryOut, &wasmParamsRes))
 	requireT.Equal(
-		getMintFee(ctx, t, chain.ClientContext), wasmParamsRes.Params.MintFee,
+		chain.QueryAssetNFTParams(ctx, t).MintFee, wasmParamsRes.Params.MintFee,
 	)
 
 	// ********** Class **********

--- a/integration-tests/upgrade/ft_test.go
+++ b/integration-tests/upgrade/ft_test.go
@@ -3,7 +3,6 @@
 package upgrade
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -85,7 +84,7 @@ func (ft *ftV1UpgradeTest) Before(t *testing.T) {
 			&assetfttypes.MsgUpgradeTokenV1{},
 			&assetfttypes.MsgUpgradeTokenV1{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount.MulRaw(8),
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount.MulRaw(8),
 	})
 
 	ft.issueV0TokenWithoutFeatures(t)
@@ -183,7 +182,7 @@ func (ft *ftV1UpgradeTest) issueV0TokenWithFeaturesWASM(t *testing.T) {
 		modules.FTWASM,
 		integrationtests.InstantiateConfig{
 			// we add the initial amount to let the contract issue the token on behalf of it
-			Amount:     getIssueFee(ctx, t, chain.ClientContext),
+			Amount:     chain.QueryAssetFTParams(ctx, t).IssueFee,
 			AccessType: wasmtypes.AccessTypeUnspecified,
 			Payload:    issuerFTInstantiatePayload,
 			Label:      "fungible_token",
@@ -226,7 +225,7 @@ func (ft *ftV1UpgradeTest) issueV0TokenWithoutFeaturesWASM(t *testing.T) {
 		modules.FTWASM,
 		integrationtests.InstantiateConfig{
 			// we add the initial amount to let the contract issue the token on behalf of it
-			Amount:     getIssueFee(ctx, t, chain.ClientContext),
+			Amount:     chain.QueryAssetFTParams(ctx, t).IssueFee,
 			AccessType: wasmtypes.AccessTypeUnspecified,
 			Payload:    issuerFTInstantiatePayload,
 			Label:      "fungible_token",
@@ -829,7 +828,7 @@ func (ft *ftFeaturesTest) Before(t *testing.T) {
 		Messages: []sdk.Msg{
 			&assetfttypes.MsgIssue{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 
 	issueMsg := &assetfttypes.MsgIssue{
@@ -900,7 +899,7 @@ func (ft *ftFeaturesTest) tryCreatingTokenWithInvalidFeature(t *testing.T) {
 		Messages: []sdk.Msg{
 			&assetfttypes.MsgIssue{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 
 	issueMsg := &assetfttypes.MsgIssue{
@@ -938,7 +937,7 @@ func (ft *ftFeaturesTest) tryCreatingTokenWithDuplicatedFeature(t *testing.T) {
 		Messages: []sdk.Msg{
 			&assetfttypes.MsgIssue{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 
 	issueMsg := &assetfttypes.MsgIssue{
@@ -976,7 +975,7 @@ func (ft *ftFeaturesTest) createValidToken(t *testing.T) {
 		Messages: []sdk.Msg{
 			&assetfttypes.MsgIssue{},
 		},
-		Amount: getIssueFee(ctx, t, chain.ClientContext).Amount,
+		Amount: chain.QueryAssetFTParams(ctx, t).IssueFee.Amount,
 	})
 
 	issueMsg := &assetfttypes.MsgIssue{
@@ -1001,12 +1000,4 @@ func (ft *ftFeaturesTest) createValidToken(t *testing.T) {
 		issueMsg,
 	)
 	requireT.NoError(err)
-}
-
-func getIssueFee(ctx context.Context, t *testing.T, clientCtx client.Context) sdk.Coin {
-	queryClient := assetfttypes.NewQueryClient(clientCtx)
-	resp, err := queryClient.Params(ctx, &assetfttypes.QueryParamsRequest{})
-	require.NoError(t, err)
-
-	return resp.Params.IssueFee
 }


### PR DESCRIPTION
## Description

This PR replaces duplicated `getIssueFee` helper func in multiple locations with a single `QueryAssetFTParams` method inside `CoreumChain` struct.
Same refactoring applied to asset/nft params to avoid same issue in the future.
The idea is to avoid code duplication & have a single universal method to query all params for asset/ft & asset/nft modules.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/coreum/581)
<!-- Reviewable:end -->
