### PR TITLE
Switch to crust `v0.47-migration-v2` branch in CI

### DIFF
--- a/.github/workflows/ci-v0.47-migration.yml
+++ b/.github/workflows/ci-v0.47-migration.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           repository: CoreumFoundation/crust
           path: crust
-          ref: dzmitryhil/update-v0.47-migration-to-v2-compatible # FIXME(dzmitryhil) change to v0.47-migration-v2
+          ref: v0.47-migration-v2
       - name: Set up crust
         run: echo "$(pwd)/crust/bin" >> $GITHUB_PATH
       - name: Setup go cache


### PR DESCRIPTION
# Description

Since crust PR for v47 migration has already been merged to long-lived branch `v0.47-migration-v2` & old one is removed we have to switch to it in CI file.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/coreum/602)
<!-- Reviewable:end -->
