### PR TITLE
Remove legacy routers and simulations functions

### DIFF
--- a/x/asset/ft/module.go
+++ b/x/asset/ft/module.go
@@ -127,21 +127,6 @@ func (am AppModule) Name() string {
 	return am.AppModuleBasic.Name()
 }
 
-// Route returns the asset ft module's message routing key.
-// FIXME(v47-module-config): remove or replace with corresponding component
-/* func (am AppModule) Route() sdk.Route {
-	return sdk.Route{}
-}
-
-// QuerierRoute returns the asset ft module's query routing key.
-func (AppModule) QuerierRoute() string { return types.QuerierRoute }
-
-// LegacyQuerierHandler returns the asset ft module's Querier.
-// FIXME(v47-module-config): remove or replace with corresponding component
-/* func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sdk.Querier {
-	return nil
-} */
-
 // RegisterServices registers a GRPC query service to respond to the
 // module-specific GRPC queries.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
@@ -191,12 +176,6 @@ func (AppModule) GenerateGenesisState(_ *module.SimulationState) {}
 func (AppModule) ProposalContents(_ module.SimulationState) []simtypes.WeightedProposalContent { //nolint:staticcheck // we need to keep backward compatibility
 	return nil
 }
-
-// RandomizedParams creates randomized asset ft param changes for the simulator.
-// FIXME(v47-module-config): remove or replace with corresponding component
-/* func (AppModule) RandomizedParams(_ *rand.Rand) []simtypes.ParamChange {
-	return nil
-} */
 
 // RegisterStoreDecoder registers a decoder for asset ft module's types.
 func (am AppModule) RegisterStoreDecoder(_ sdk.StoreDecoderRegistry) {}

--- a/x/asset/nft/module.go
+++ b/x/asset/nft/module.go
@@ -124,20 +124,8 @@ func (am AppModule) Name() string {
 	return am.AppModuleBasic.Name()
 }
 
-// Route returns the assetnft module's message routing key.
-// FIXME(v47-module-config): remove or replace with corresponding component
-//  func (am AppModule) Route() sdk.Route {
-//	  return sdk.Route{}
-//  }
-
 // QuerierRoute returns the assetnft module's query routing key.
 func (AppModule) QuerierRoute() string { return types.QuerierRoute }
-
-// LegacyQuerierHandler returns the asset module's Querier.
-// FIXME(v47-module-config): remove or replace with corresponding component
-/* func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sdk.Querier {
-	return nil
-} */
 
 // RegisterServices registers a GRPC query service to respond to the
 // module-specific GRPC queries.
@@ -187,12 +175,6 @@ func (AppModule) GenerateGenesisState(_ *module.SimulationState) {}
 func (AppModule) ProposalContents(_ module.SimulationState) []simtypes.WeightedProposalContent { //nolint:staticcheck // we need to keep backward compatibility
 	return nil
 }
-
-// RandomizedParams creates randomized fee param changes for the simulator.
-// FIXME(v47-module-config): remove or replace with corresponding component
-/* func (AppModule) RandomizedParams(_ *rand.Rand) []simtypes.ParamChange {
-	  return nil
-} */
 
 // RegisterStoreDecoder registers a decoder for assetnft module's types.
 func (am AppModule) RegisterStoreDecoder(_ sdk.StoreDecoderRegistry) {}

--- a/x/customparams/module.go
+++ b/x/customparams/module.go
@@ -99,18 +99,8 @@ func (AppModule) Name() string { return types.ModuleName }
 // RegisterInvariants registers the customparams module invariants.
 func (am AppModule) RegisterInvariants(ir sdk.InvariantRegistry) {}
 
-// Route returns the message routing key for the customparams module.
-// FIXME(v47-module-config): remove or replace with corresponding component
-// func (am AppModule) Route() sdk.Route { return sdk.Route{} }
-
 // QuerierRoute returns the customparams module's querier route name.
 func (AppModule) QuerierRoute() string { return types.RouterKey }
-
-// LegacyQuerierHandler returns the customparams module sdk.Querier.
-// FIXME(v47-module-config): remove or replace with corresponding component
-/* func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sdk.Querier {
-	return nil
-} */
 
 // InitGenesis performs genesis initialization for the customparams module. It returns
 // no validator updates.
@@ -144,12 +134,6 @@ func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
 func (AppModule) ProposalContents(_ module.SimulationState) []simtypes.WeightedProposalContent { //nolint:staticcheck // we need to keep backward compatibility
 	return nil
 }
-
-// RandomizedParams creates randomized customparams param changes for the simulator.
-// FIXME(v47-module-config): remove or replace with corresponding component
-/* func (AppModule) RandomizedParams(r *rand.Rand) []simtypes.ParamChange {
-	return nil
-} */
 
 // RegisterStoreDecoder registers a decoder for supply module's types.
 func (am AppModule) RegisterStoreDecoder(_ sdk.StoreDecoderRegistry) {}

--- a/x/delay/module.go
+++ b/x/delay/module.go
@@ -90,18 +90,8 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {}
 // RegisterInvariants registers the delay module invariants.
 func (am AppModule) RegisterInvariants(ir sdk.InvariantRegistry) {}
 
-// Route returns the message routing key for the delay module.
-// FIXME(v47-module-config): remove or replace with corresponding component
-// func (am AppModule) Route() sdk.Route { return sdk.Route{} }
-
 // QuerierRoute returns the delay module's querier route name.
 func (AppModule) QuerierRoute() string { return types.RouterKey }
-
-// LegacyQuerierHandler returns the customparams module sdk.Querier.
-// FIXME(v47-module-config): remove or replace with corresponding component
-/* func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sdk.Querier {
-	return nil
-} */
 
 // InitGenesis performs genesis initialization for the delay module.
 func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.RawMessage) []abci.ValidatorUpdate {
@@ -144,12 +134,6 @@ func (AppModule) GenerateGenesisState(simState *module.SimulationState) {}
 func (AppModule) ProposalContents(_ module.SimulationState) []simtypes.WeightedProposalContent { //nolint:staticcheck // we need to keep backward compatibility
 	return nil
 }
-
-// RandomizedParams creates randomized delay param changes for the simulator.
-// FIXME(v47-module-config): remove or replace with corresponding component
-/*func (AppModule) RandomizedParams(r *rand.Rand) []simtypes.ParamChange {
-	return nil
-}*/
 
 // RegisterStoreDecoder registers a decoder for supply module's types.
 func (am AppModule) RegisterStoreDecoder(_ sdk.StoreDecoderRegistry) {}

--- a/x/feemodel/module.go
+++ b/x/feemodel/module.go
@@ -117,18 +117,6 @@ func (AppModule) Name() string { return types.ModuleName }
 // RegisterInvariants registers the fee module invariants.
 func (am AppModule) RegisterInvariants(ir sdk.InvariantRegistry) {}
 
-// FIXME(v47-module-config): remove or replace with corresponding component
-// Route returns the message routing key for the fee module.
-/* func (am AppModule) Route() sdk.Route { return sdk.Route{} } */
-// FIXME(v47-module-config): remove or replace with corresponding component
-// QuerierRoute returns the fee module's querier route name.
-/* func (AppModule) QuerierRoute() string { return types.RouterKey } */
-// FIXME(v47-module-config): remove or replace with corresponding component
-// LegacyQuerierHandler returns the fee module sdk.Querier.
-/* func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sdk.Querier {
-	return nil
-} */
-
 // InitGenesis performs genesis initialization for the fee module. It returns
 // no validator updates.
 func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, data json.RawMessage) []abci.ValidatorUpdate {
@@ -187,12 +175,6 @@ func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
 func (AppModule) ProposalContents(_ module.SimulationState) []simtypes.WeightedProposalContent { //nolint:staticcheck // we need to keep backward compatibility
 	return nil
 }
-
-// FIXME(v47-module-config): remove or replace with corresponding component
-// RandomizedParams creates randomized fee param changes for the simulator.
-/* func (AppModule) RandomizedParams(r *rand.Rand) []simtypes.ParamChange {
-	return nil
-} */
 
 // RegisterStoreDecoder registers a decoder for supply module's types.
 func (am AppModule) RegisterStoreDecoder(_ sdk.StoreDecoderRegistry) {}

--- a/x/nft/module/module.go
+++ b/x/nft/module/module.go
@@ -118,12 +118,6 @@ func (AppModule) Name() string {
 // RegisterInvariants does nothing, there are no invariants to enforce.
 func (AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
 
-// Route returns the message routing key for the staking module.
-// FIXME(v47-module-config): remove or replace with corresponding component
-/* func (am AppModule) Route() sdk.Route {
-	return sdk.NewRoute(nft.RouterKey, nil)
-} */
-
 // NewHandler returns the new module handler.
 func (am AppModule) NewHandler() sdk.Handler {
 	return nil
@@ -131,11 +125,6 @@ func (am AppModule) NewHandler() sdk.Handler {
 
 // QuerierRoute returns the route we respond to for abci queries.
 func (AppModule) QuerierRoute() string { return "" }
-
-// LegacyQuerierHandler returns the nft module sdk.Querier.
-/* func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sdk.Querier {
-	return nil
-} */
 
 // InitGenesis performs genesis initialization for the nft module. It returns
 // no validator updates.
@@ -174,12 +163,6 @@ func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
 func (am AppModule) ProposalContents(simState module.SimulationState) []simtypes.WeightedProposalContent { //nolint:staticcheck // we need to keep backward compatibility
 	return nil
 }
-
-// RandomizedParams creates randomized nft param changes for the simulator.
-// FIXME(v47-module-config): remove or replace with corresponding component
-/* func (AppModule) RandomizedParams(r *rand.Rand) []simtypes.ParamChange {
-	return nil
-} */
 
 // RegisterStoreDecoder registers a decoder for nft module's types.
 func (am AppModule) RegisterStoreDecoder(sdr sdk.StoreDecoderRegistry) {

--- a/x/wibctransfer/module_test.go
+++ b/x/wibctransfer/module_test.go
@@ -47,7 +47,6 @@ func (c *configuratorMock) RegisterMigration(moduleName string, forVersion uint6
 // The test checks the migration registration of the original IBC transfer module.
 // Since we override the "Register Services" we want to be sure that after the update of the SDK,
 // The original transfer module won't have unexpected migrations.
-// FIXME(v47-module-config): validate that the updated wrapping is correct and wraps all required methods.
 func TestAppModuleOriginalTransfer_RegisterServices(t *testing.T) {
 	transferModule := transfer.NewAppModule(ibctransferkeeper.Keeper{})
 	configurator := newConfiguratorMock()


### PR DESCRIPTION
# Description
This PR, removes the functions from Modules, related to legacy routers and simulations. that code was already commented and we needed to reasearch a replacement. As outlined [here](https://docs.cosmos.network/v0.47/migrations/upgrading#appmodule-interface), all those functions are fully deprecated and must be removed. 
# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/coreum/607)
<!-- Reviewable:end -->
