### PR TITLE
Limit the gas taken by WASM simulation

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -802,6 +802,7 @@ func New(
 			IBCKeeper:              app.IBCKeeper,
 			FeeModelKeeper:         app.FeeModelKeeper,
 			WasmTXCounterStoreKey:  keys[wasmtypes.StoreKey],
+			WasmConfig:             wasmConfig,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
# Description

By fixing this PR, the limit is taken from `--wasm.simulation_gas_limit` CLI flag. Default value is `3 000 000`.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [ ] Provide a concise and meaningful description
- [ ] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/coreum/626)
<!-- Reviewable:end -->
