### PR TITLE
Close IBC channels that are opened in integration-tests

### DIFF
--- a/integration-tests/ibc/wasm_test.go
+++ b/integration-tests/ibc/wasm_test.go
@@ -234,7 +234,7 @@ func TestIBCCallFromSmartContract(t *testing.T) {
 	requireT.NotEmpty(osmosisIBCPort)
 	t.Logf("Osmisis contrac IBC port:%s", osmosisIBCPort)
 
-	integrationtests.CreateIBCChannelsAndConnect(
+	closerFunc := integrationtests.CreateIBCChannelsAndConnect(
 		ctx,
 		t,
 		coreumChain.Chain,
@@ -244,6 +244,7 @@ func TestIBCCallFromSmartContract(t *testing.T) {
 		channelIBCVersion,
 		ibcchanneltypes.UNORDERED,
 	)
+	defer closerFunc()
 
 	coreumToOsmosisChannelID := coreumChain.AwaitForIBCChannelID(ctx, t, coreumIBCPort, osmosisChain.ChainSettings.ChainID)
 	osmosisToCoreumChannelID := osmosisChain.AwaitForIBCChannelID(ctx, t, osmosisIBCPort, coreumChain.ChainSettings.ChainID)


### PR DESCRIPTION
# Description
This PR, fixes the failing tests that were failing after the upgrade. Apparently, we must close the channel that we create in integration tests, so the outside relayer is not confused. 
# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/coreum/640)
<!-- Reviewable:end -->
