### PR TITLE
Reestimate deterministic gas

### DIFF
--- a/x/deterministicgas/config.go
+++ b/x/deterministicgas/config.go
@@ -66,101 +66,99 @@ func DefaultConfig() Config {
 		FreeSignatures: 1,
 	}
 
-	// FIXME(v47-deterministic): re-estimate and update all values + regenerate doc
 	cfg.gasByMsg = map[MsgURL]gasByMsgFunc{
 		// asset/ft
 		MsgToMsgURL(&assetfttypes.MsgIssue{}):               constantGasFunc(70000),
-		MsgToMsgURL(&assetfttypes.MsgMint{}):                constantGasFunc(11000),
-		MsgToMsgURL(&assetfttypes.MsgBurn{}):                constantGasFunc(23000),
-		MsgToMsgURL(&assetfttypes.MsgFreeze{}):              constantGasFunc(5000),
-		MsgToMsgURL(&assetfttypes.MsgUnfreeze{}):            constantGasFunc(2500),
-		MsgToMsgURL(&assetfttypes.MsgGloballyFreeze{}):      constantGasFunc(5000),
+		MsgToMsgURL(&assetfttypes.MsgMint{}):                constantGasFunc(11000 * 2.78),
+		MsgToMsgURL(&assetfttypes.MsgBurn{}):                constantGasFunc(23000 * 1.52),
+		MsgToMsgURL(&assetfttypes.MsgFreeze{}):              constantGasFunc(5000 * 1.72),
+		MsgToMsgURL(&assetfttypes.MsgUnfreeze{}):            constantGasFunc(2500 * 1.54),
+		MsgToMsgURL(&assetfttypes.MsgGloballyFreeze{}):      constantGasFunc(5000 * 1.04),
 		MsgToMsgURL(&assetfttypes.MsgGloballyUnfreeze{}):    constantGasFunc(2500),
-		MsgToMsgURL(&assetfttypes.MsgSetWhitelistedLimit{}): constantGasFunc(5000),
-		MsgToMsgURL(&assetfttypes.MsgUpgradeTokenV1{}):      constantGasFunc(25000),
+		MsgToMsgURL(&assetfttypes.MsgSetWhitelistedLimit{}): constantGasFunc(5000 * 1.76),
+		MsgToMsgURL(&assetfttypes.MsgUpgradeTokenV1{}):      constantGasFunc(25000), // TODO: Reestimate when next token upgrade is prepared
 
 		// asset/nft
-		MsgToMsgURL(&assetnfttypes.MsgBurn{}):                constantGasFunc(16000),
+		MsgToMsgURL(&assetnfttypes.MsgBurn{}):                constantGasFunc(16000 * 1.64),
 		MsgToMsgURL(&assetnfttypes.MsgIssueClass{}):          constantGasFunc(16000),
 		MsgToMsgURL(&assetnfttypes.MsgMint{}):                constantGasFunc(39000),
-		MsgToMsgURL(&assetnfttypes.MsgFreeze{}):              constantGasFunc(7000),
+		MsgToMsgURL(&assetnfttypes.MsgFreeze{}):              constantGasFunc(7000 * 1.19),
 		MsgToMsgURL(&assetnfttypes.MsgUnfreeze{}):            constantGasFunc(5000),
 		MsgToMsgURL(&assetnfttypes.MsgAddToWhitelist{}):      constantGasFunc(7000),
 		MsgToMsgURL(&assetnfttypes.MsgRemoveFromWhitelist{}): constantGasFunc(3500),
 
 		// authz
-		MsgToMsgURL(&authz.MsgExec{}):   cfg.authzMsgExecGasFunc(AuthzExecOverhead),
-		MsgToMsgURL(&authz.MsgGrant{}):  constantGasFunc(7000),
-		MsgToMsgURL(&authz.MsgRevoke{}): constantGasFunc(2500),
+		MsgToMsgURL(&authz.MsgExec{}):   cfg.authzMsgExecGasFunc(AuthzExecOverhead), // how to do this?
+		MsgToMsgURL(&authz.MsgGrant{}):  constantGasFunc(7000 * 3.95),
+		MsgToMsgURL(&authz.MsgRevoke{}): constantGasFunc(2500 * 3.19),
 
 		// bank
 		MsgToMsgURL(&banktypes.MsgSend{}):      bankSendMsgGasFunc(BankSendPerCoinGas),
 		MsgToMsgURL(&banktypes.MsgMultiSend{}): bankMultiSendMsgGasFunc(BankMultiSendPerOperationsGas),
 
 		// distribution
-		MsgToMsgURL(&distributiontypes.MsgFundCommunityPool{}):           constantGasFunc(15000),
+		MsgToMsgURL(&distributiontypes.MsgFundCommunityPool{}):           constantGasFunc(15000 * 1.11),
 		MsgToMsgURL(&distributiontypes.MsgSetWithdrawAddress{}):          constantGasFunc(5000),
-		MsgToMsgURL(&distributiontypes.MsgWithdrawDelegatorReward{}):     constantGasFunc(65000),
+		MsgToMsgURL(&distributiontypes.MsgWithdrawDelegatorReward{}):     constantGasFunc(65000 * 1.21),
 		MsgToMsgURL(&distributiontypes.MsgWithdrawValidatorCommission{}): constantGasFunc(22000),
 
 		// feegrant
-		MsgToMsgURL(&feegranttypes.MsgGrantAllowance{}):  constantGasFunc(10000),
+		MsgToMsgURL(&feegranttypes.MsgGrantAllowance{}):  constantGasFunc(10000 * 1.10),
 		MsgToMsgURL(&feegranttypes.MsgRevokeAllowance{}): constantGasFunc(2500),
 
 		// gov
 		// FIXME(v47-deterministic): check that if we want to support both go types
-		MsgToMsgURL(&govtypesv1beta1.MsgVote{}):         constantGasFunc(7000),
+		MsgToMsgURL(&govtypesv1beta1.MsgVote{}):         constantGasFunc(7000 * 0.88),
 		MsgToMsgURL(&govtypesv1beta1.MsgVoteWeighted{}): constantGasFunc(9000),
-		MsgToMsgURL(&govtypesv1beta1.MsgDeposit{}):      constantGasFunc(52000),
+		MsgToMsgURL(&govtypesv1beta1.MsgDeposit{}):      constantGasFunc(52000 * 1.63),
 
-		MsgToMsgURL(&govtypesv1.MsgVote{}):         constantGasFunc(7000),
-		MsgToMsgURL(&govtypesv1.MsgVoteWeighted{}): constantGasFunc(9000),
-		MsgToMsgURL(&govtypesv1.MsgDeposit{}):      constantGasFunc(52000),
+		MsgToMsgURL(&govtypesv1.MsgVote{}):         constantGasFunc(7000 * 0.88),
+		MsgToMsgURL(&govtypesv1.MsgVoteWeighted{}): constantGasFunc(9000 * 0.72),
+		MsgToMsgURL(&govtypesv1.MsgDeposit{}):      constantGasFunc(52000), // missing
 
 		// nft
-		MsgToMsgURL(&nfttypes.MsgSend{}): constantGasFunc(16000),
+		MsgToMsgURL(&nfttypes.MsgSend{}): constantGasFunc(16000 * 1.55),
 
 		// slashing
-		MsgToMsgURL(&slashingtypes.MsgUnjail{}): constantGasFunc(25000),
+		MsgToMsgURL(&slashingtypes.MsgUnjail{}): constantGasFunc(25000), // missing
 
 		// staking
-		MsgToMsgURL(&stakingtypes.MsgDelegate{}):        constantGasFunc(69000),
+		MsgToMsgURL(&stakingtypes.MsgDelegate{}):        constantGasFunc(69000 * 1.21),
 		MsgToMsgURL(&stakingtypes.MsgUndelegate{}):      constantGasFunc(112000),
-		MsgToMsgURL(&stakingtypes.MsgBeginRedelegate{}): constantGasFunc(142000),
-		MsgToMsgURL(&stakingtypes.MsgCreateValidator{}): constantGasFunc(76000),
+		MsgToMsgURL(&stakingtypes.MsgBeginRedelegate{}): constantGasFunc(142000 * 1.11),
+		MsgToMsgURL(&stakingtypes.MsgCreateValidator{}): constantGasFunc(76000 * 1.54),
 		MsgToMsgURL(&stakingtypes.MsgEditValidator{}):   constantGasFunc(13000),
 
 		// vesting
-		MsgToMsgURL(&vestingtypes.MsgCreateVestingAccount{}): constantGasFunc(25000),
+		MsgToMsgURL(&vestingtypes.MsgCreateVestingAccount{}): constantGasFunc(25000 * 1.2),
 
 		// wasm
 		MsgToMsgURL(&wasmtypes.MsgUpdateAdmin{}): constantGasFunc(8000),
 		MsgToMsgURL(&wasmtypes.MsgClearAdmin{}):  constantGasFunc(6500),
 
 		// ibc transfer
-		MsgToMsgURL(&ibctransfertypes.MsgTransfer{}): constantGasFunc(37000),
+		MsgToMsgURL(&ibctransfertypes.MsgTransfer{}): constantGasFunc(37000 * 1.47),
 	}
 
-	// FIXME(v47-deterministic): validate all new un-deterministic messages and move to deterministic if possible
 	registerNondeterministicGasFuncs(
 		&cfg,
 		[]sdk.Msg{
 			// auth
-			&authtypes.MsgUpdateParams{},
+			&authtypes.MsgUpdateParams{}, // This is non-deterministic because all the goc proposals are non-deterministic anyway
 
 			// bank
-			&banktypes.MsgSetSendEnabled{},
-			&banktypes.MsgUpdateParams{},
+			&banktypes.MsgSetSendEnabled{}, // This is non-deterministic because all the goc proposals are non-deterministic anyway
+			&banktypes.MsgUpdateParams{},   // This is non-deterministic because all the goc proposals are non-deterministic anyway
 
 			// consensus
-			&consensustypes.MsgUpdateParams{},
+			&consensustypes.MsgUpdateParams{}, // This is non-deterministic because all the goc proposals are non-deterministic anyway
 
 			// crisis
-			&crisistypes.MsgUpdateParams{},
+			&crisistypes.MsgUpdateParams{}, // This is non-deterministic because all the goc proposals are non-deterministic anyway
 
 			// distribution
-			&distributiontypes.MsgUpdateParams{},
-			&distributiontypes.MsgCommunityPoolSpend{},
+			&distributiontypes.MsgUpdateParams{},       // This is non-deterministic because all the goc proposals are non-deterministic anyway
+			&distributiontypes.MsgCommunityPoolSpend{}, // This is non-deterministic because all the goc proposals are non-deterministic anyway
 
 			// gov
 			// MsgSubmitProposal is defined as nondeterministic because it runs a proposal handler function
@@ -170,7 +168,7 @@ func DefaultConfig() Config {
 			// FIXME(v47-deterministic): check that if we want to support both go types
 			&govtypesv1.MsgSubmitProposal{},
 			&govtypesv1.MsgExecLegacyContent{},
-			&govtypesv1.MsgUpdateParams{},
+			&govtypesv1.MsgUpdateParams{}, // This is non-deterministic because all the goc proposals are non-deterministic anyway
 
 			// crisis
 			// MsgVerifyInvariant is defined as nondeterministic since fee
@@ -184,22 +182,22 @@ func DefaultConfig() Config {
 			&evidencetypes.MsgSubmitEvidence{},
 
 			// mint
-			&minttypes.MsgUpdateParams{},
+			&minttypes.MsgUpdateParams{}, // This is non-deterministic because all the goc proposals are non-deterministic anyway
 
 			// staking
-			&stakingtypes.MsgUpdateParams{},
+			&stakingtypes.MsgUpdateParams{}, // This is non-deterministic because all the goc proposals are non-deterministic anyway
 			// FIXME(v47-deterministic): add message to deterministic (we have separate task for it)
 			&stakingtypes.MsgCancelUnbondingDelegation{},
 
 			// slashing
-			&slashingtypes.MsgUpdateParams{},
+			&slashingtypes.MsgUpdateParams{}, // This is non-deterministic because all the goc proposals are non-deterministic anyway
 
 			// slashing
-			&slashingtypes.MsgUpdateParams{},
+			&slashingtypes.MsgUpdateParams{}, // This is non-deterministic because all the goc proposals are non-deterministic anyway
 
 			// upgrade
-			&upgradetypes.MsgCancelUpgrade{},
-			&upgradetypes.MsgSoftwareUpgrade{},
+			&upgradetypes.MsgCancelUpgrade{},   // This is non-deterministic because all the goc proposals are non-deterministic anyway
+			&upgradetypes.MsgSoftwareUpgrade{}, // This is non-deterministic because all the goc proposals are non-deterministic anyway
 
 			// vesting
 			// FIXME(v47-deterministic): add message to deterministic (we have separate task for it)
@@ -216,7 +214,7 @@ func DefaultConfig() Config {
 			&wasmtypes.MsgIBCSend{},
 			&wasmtypes.MsgIBCCloseChannel{},
 			&wasmtypes.MsgUpdateInstantiateConfig{},
-			&wasmtypes.MsgUpdateParams{},
+			&wasmtypes.MsgUpdateParams{}, // This is non-deterministic because all the goc proposals are non-deterministic anyway
 			&wasmtypes.MsgUnpinCodes{},
 			&wasmtypes.MsgPinCodes{},
 			&wasmtypes.MsgSudoContract{},


### PR DESCRIPTION
# Description

Here are the metrics after reestimating:

```
coreum.asset.ft.v1.MsgBurn		1.09	1.00
coreum.asset.ft.v1.MsgFreeze		1.20	1.00
coreum.asset.ft.v1.MsgGloballyFreeze	1.15	0.98
coreum.asset.ft.v1.MsgGloballyUnfreeze	1.08	0.97
coreum.asset.ft.v1.MsgIssue		1.30	0.80
coreum.asset.ft.v1.MsgMint		1.12	1.00
coreum.asset.ft.v1.MsgSetWhitelistedLimit	1.17	0.43
coreum.asset.ft.v1.MsgUnfreeze		2.73	0.99
coreum.asset.nft.v1.MsgAddToWhitelist	1.10	1.10
coreum.asset.nft.v1.MsgBurn		1.05	1.00
coreum.asset.nft.v1.MsgFreeze		1.01	0.94
coreum.asset.nft.v1.MsgIssueClass	1.74	0.92
coreum.asset.nft.v1.MsgMint		1.72	0.73
coreum.asset.nft.v1.MsgRemoveFromWhitelist	1.04	0.99
coreum.asset.nft.v1.MsgUnfreeze		0.99	0.95
coreum.nft.v1beta1.MsgSend		1.06	0.91
cosmos.authz.v1beta1.MsgExec		1.06	1.02
cosmos.authz.v1beta1.MsgGrant		1.01	1.00
cosmos.authz.v1beta1.MsgRevoke		1.00	1.00
cosmos.bank.v1beta1.MsgMultiSend	2.20	0.64
cosmos.bank.v1beta1.MsgSend		3.76	0.63
cosmos.distribution.v1beta1.MsgFundCommunityPool	1.00	1.00
cosmos.distribution.v1beta1.MsgSetWithdrawAddress	0.89	0.89
cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward	1.21	1.21
cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission	1.07	1.07
cosmos.feegrant.v1beta1.MsgGrantAllowance	1.00	1.00
cosmos.feegrant.v1beta1.MsgRevokeAllowance	1.02	1.02
cosmos.gov.v1.MsgVote			1.00	1.00
cosmos.gov.v1.MsgVoteWeighted		1.00	1.00
cosmos.gov.v1beta1.MsgDeposit		1.00	1.00
cosmos.gov.v1beta1.MsgVote		0.88	0.88
cosmos.staking.v1beta1.MsgBeginRedelegate	1.00	1.00
cosmos.staking.v1beta1.MsgCreateValidator	1.02	1.00
cosmos.staking.v1beta1.MsgDelegate	1.00	0.86
cosmos.staking.v1beta1.MsgEditValidator	0.99	0.99
cosmos.staking.v1beta1.MsgUndelegate	1.26	0.97
cosmos.vesting.v1beta1.MsgCreateVestingAccount	1.40	1.01
cosmwasm.wasm.v1.MsgClearAdmin		1.01	1.01
cosmwasm.wasm.v1.MsgUpdateAdmin		1.00	1.00
ibc.applications.transfer.v1.MsgTransfer	2.14	1.00
```

Some transactions can't be estimated because have no integration tests using them, we should add:

```
slashingtypes.MsgUnjail
govtypesv1.MsgDeposit
```

Also we should discuss how we approach these messages:

```
coreum.asset.nft.v1.MsgIssueClass
coreum.asset.nft.v1.MsgMint
cosmos.bank.v1beta1.MsgMultiSend
cosmos.bank.v1beta1.MsgSend
```

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.
