### PR TITLE
Stop running `TestStakingValidatorCRUDAndStaking` in parallel with other tests

### DIFF
--- a/integration-tests/modules/staking_test.go
+++ b/integration-tests/modules/staking_test.go
@@ -100,7 +100,7 @@ func TestStakingProposalParamChange(t *testing.T) {
 
 // TestStakingValidatorCRUDAndStaking checks validator creation, delegation and undelegation operations work correctly.
 func TestStakingValidatorCRUDAndStaking(t *testing.T) {
-	t.Parallel()
+	// This test cannot be run in parallel because it modifies staking params, affecting other tests.
 
 	ctx, chain := integrationtests.NewCoreumTestingContext(t)
 


### PR DESCRIPTION
# Description

`TestStakingValidatorCRUDAndStaking` conflicts with `TestStakingProposalParamChange`

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/coreum/649)
<!-- Reviewable:end -->
