### PR TITLE
Add BroadcastTx sync raw log to the error message.

### DIFF
--- a/pkg/client/tx.go
+++ b/pkg/client/tx.go
@@ -400,7 +400,7 @@ func broadcastTxSync(ctx context.Context, clientCtx Context, txBytes []byte) (*s
 		}
 	} else if res.TxResponse.Code != 0 {
 		return nil, errors.Wrapf(sdkerrors.ABCIError(res.TxResponse.Codespace, res.TxResponse.Code, res.TxResponse.Logs.String()),
-			"transaction '%s' failed", res.TxResponse.TxHash)
+			"transaction '%s' failed, raw log:%s", res.TxResponse.TxHash, res.TxResponse.RawLog)
 	}
 
 	return res.TxResponse, nil


### PR DESCRIPTION
# Description

For better error tracing we need to add not just `Log`, but `RawLog` to the error message for the transactions broadcasting.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.
