### PR TITLE
Run Cosmos relayer process inside `TestIBCCallFromSmartContract` integration test

### DIFF
--- a/integration-tests/ibc/ibc.go
+++ b/integration-tests/ibc/ibc.go
@@ -66,6 +66,9 @@ func CreateOpenIBCChannelsAndStartRelaying(
 
 	pathName := fmt.Sprintf("%s-%s", srcChain.ChainSettings.ChainID, dstChain.ChainSettings.ChainID)
 
+	// port name samples:
+	//  coreum: wasm.devcore14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sd4f0ak
+	//  osmosis: wasm.osmo14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sq2r9g9
 	require.NoError(t, relayerSrcChain.CreateOpenChannels(
 		ctx,
 		relayerDstChain,

--- a/integration-tests/ibc/ibc.go
+++ b/integration-tests/ibc/ibc.go
@@ -66,9 +66,6 @@ func CreateOpenIBCChannelsAndStartRelaying(
 
 	pathName := fmt.Sprintf("%s-%s", srcChain.ChainSettings.ChainID, dstChain.ChainSettings.ChainID)
 
-	// port name samples:
-	//  coreum: wasm.devcore14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sd4f0ak
-	//  osmosis: wasm.osmo14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sq2r9g9
 	require.NoError(t, relayerSrcChain.CreateOpenChannels(
 		ctx,
 		relayerDstChain,
@@ -107,7 +104,7 @@ func CreateOpenIBCChannelsAndStartRelaying(
 
 	go func() {
 		err := <-relErrCh
-		if !errors.Is(err, context.Canceled) {
+		if errors.Is(err, context.Canceled) {
 			return
 		}
 		require.NoError(t, err, "Cosmos Relayer start error")

--- a/integration-tests/ibc/wasm_test.go
+++ b/integration-tests/ibc/wasm_test.go
@@ -159,8 +159,8 @@ func TestIBCTransferFromSmartContract(t *testing.T) {
 
 // TestIBCCallFromSmartContract tests the WASM contract calls via WASM IBC channel.
 func TestIBCCallFromSmartContract(t *testing.T) {
-	// Temporary skip this test because it is incompatible with crust but crust PR needs changes from coreum.
-	t.SkipNow()
+	// FIXME: Temporary skip this test because it is incompatible with crust but crust PR needs changes from coreum.
+	//t.SkipNow()
 
 	// We don't enable the t.Parallel here since that test uses the config unseal hack.
 	// Config unseal is needed to run cosmos relayer which interacts with both chain SDK configs internally.
@@ -258,7 +258,7 @@ func TestIBCCallFromSmartContract(t *testing.T) {
 	awaitWasmCounterValue(ctx, t, coreumChain.Chain, coreumToOsmosisChannelID, coreumContractAddr, 0)
 	awaitWasmCounterValue(ctx, t, osmosisChain, osmosisToCoreumChannelID, osmosisContractAddr, 0)
 
-	t.Logf("Sendng two IBC-increment transactions from coreum contract to osmosis contract")
+	t.Logf("Sending two IBC-increment transactions from coreum contract to osmosis contract")
 	executeWasmIncrement(ctx, requireT, coreumChain.Chain, coreumCaller, coreumToOsmosisChannelID, coreumContractAddr)
 	executeWasmIncrement(ctx, requireT, coreumChain.Chain, coreumCaller, coreumToOsmosisChannelID, coreumContractAddr)
 

--- a/integration-tests/ibc/wasm_test.go
+++ b/integration-tests/ibc/wasm_test.go
@@ -157,10 +157,10 @@ func TestIBCTransferFromSmartContract(t *testing.T) {
 	requireT.NoError(osmosisChain.AwaitForBalance(ctx, t, osmosisRecipient, expectedOsmosisRecipientBalance))
 }
 
-// TestIBCCallFromSmartContract tests the IBC contract calls.
+// TestIBCCallFromSmartContract tests the WASM contract calls via WASM IBC channel.
 func TestIBCCallFromSmartContract(t *testing.T) {
-	// we don't enable the t.Parallel here since that test uses the config unseal hack because of the cosmos relayer
-	// implementation
+	// We don't enable the t.Parallel here since that test uses the config unseal hack.
+	// Config unseal is needed to run cosmos relayer which interacts with both chain SDK configs internally.
 	restoreSDKConfig := unsealSDKConfig()
 	defer restoreSDKConfig()
 

--- a/integration-tests/ibc/wasm_test.go
+++ b/integration-tests/ibc/wasm_test.go
@@ -160,7 +160,7 @@ func TestIBCTransferFromSmartContract(t *testing.T) {
 // TestIBCCallFromSmartContract tests the WASM contract calls via WASM IBC channel.
 func TestIBCCallFromSmartContract(t *testing.T) {
 	// FIXME: Temporary skip this test because it is incompatible with crust but crust PR needs changes from coreum.
-	//t.SkipNow()
+	t.SkipNow()
 
 	// We don't enable the t.Parallel here since that test uses the config unseal hack.
 	// Config unseal is needed to run cosmos relayer which interacts with both chain SDK configs internally.

--- a/integration-tests/ibc/wasm_test.go
+++ b/integration-tests/ibc/wasm_test.go
@@ -159,6 +159,9 @@ func TestIBCTransferFromSmartContract(t *testing.T) {
 
 // TestIBCCallFromSmartContract tests the WASM contract calls via WASM IBC channel.
 func TestIBCCallFromSmartContract(t *testing.T) {
+	// Temporary skip this test because it is incompatible with crust but crust PR needs changes from coreum.
+	t.SkipNow()
+
 	// We don't enable the t.Parallel here since that test uses the config unseal hack.
 	// Config unseal is needed to run cosmos relayer which interacts with both chain SDK configs internally.
 	restoreSDKConfig := unsealSDKConfig()

--- a/integration-tests/modules/legacy_nft_assetnft_test.go
+++ b/integration-tests/modules/legacy_nft_assetnft_test.go
@@ -21,8 +21,6 @@ import (
 
 // TestAssetNFTMintLegacyNFTClient tests legacy APIs in cnft are working.
 // we should remove this test after we remove cnf module.
-//
-//nolint:staticcheck // we are testing deprecated handlers
 func TestAssetNFTMintLegacyNFTClient(t *testing.T) {
 	t.Parallel()
 
@@ -95,6 +93,7 @@ func TestAssetNFTMintLegacyNFTClient(t *testing.T) {
 	}, nftMintedEvent)
 
 	// check that token is present in the nft module
+	//nolint:staticcheck // we are testing deprecated handlers
 	nftRes, err := nftClient.NFT(ctx, &nft.QueryNFTRequest{
 		ClassId: classID,
 		Id:      nftMintedEvent.Id,
@@ -114,6 +113,7 @@ func TestAssetNFTMintLegacyNFTClient(t *testing.T) {
 	requireT.Equal(jsonData, data2.Data)
 
 	// check the owner
+	//nolint:staticcheck // we are testing deprecated handlers
 	ownerRes, err := nftClient.Owner(ctx, &nft.QueryOwnerRequest{
 		ClassId: classID,
 		Id:      nftMintedEvent.Id,
@@ -147,6 +147,7 @@ func TestAssetNFTMintLegacyNFTClient(t *testing.T) {
 	}, nftSentEvent)
 
 	// check new owner
+	//nolint:staticcheck // we are testing deprecated handlers
 	ownerRes, err = nftClient.Owner(ctx, &nft.QueryOwnerRequest{
 		ClassId: classID,
 		Id:      nftMintedEvent.Id,

--- a/integration-tests/modules/legacy_nft_assetnft_test.go
+++ b/integration-tests/modules/legacy_nft_assetnft_test.go
@@ -21,6 +21,8 @@ import (
 
 // TestAssetNFTMintLegacyNFTClient tests legacy APIs in cnft are working.
 // we should remove this test after we remove cnf module.
+//
+//nolint:staticcheck // we are testing deprecated handlers
 func TestAssetNFTMintLegacyNFTClient(t *testing.T) {
 	t.Parallel()
 
@@ -93,7 +95,7 @@ func TestAssetNFTMintLegacyNFTClient(t *testing.T) {
 	}, nftMintedEvent)
 
 	// check that token is present in the nft module
-	nftRes, err := nftClient.NFT(ctx, &nft.QueryNFTRequest{ //nolint:staticcheck // we are testing deprecated handlers
+	nftRes, err := nftClient.NFT(ctx, &nft.QueryNFTRequest{
 		ClassId: classID,
 		Id:      nftMintedEvent.Id,
 	})
@@ -112,7 +114,7 @@ func TestAssetNFTMintLegacyNFTClient(t *testing.T) {
 	requireT.Equal(jsonData, data2.Data)
 
 	// check the owner
-	ownerRes, err := nftClient.Owner(ctx, &nft.QueryOwnerRequest{ //nolint:staticcheck // we are testing deprecated handlers
+	ownerRes, err := nftClient.Owner(ctx, &nft.QueryOwnerRequest{
 		ClassId: classID,
 		Id:      nftMintedEvent.Id,
 	})
@@ -145,7 +147,7 @@ func TestAssetNFTMintLegacyNFTClient(t *testing.T) {
 	}, nftSentEvent)
 
 	// check new owner
-	ownerRes, err = nftClient.Owner(ctx, &nft.QueryOwnerRequest{ //nolint:staticcheck // we are testing deprecated handlers
+	ownerRes, err = nftClient.Owner(ctx, &nft.QueryOwnerRequest{
 		ClassId: classID,
 		Id:      nftMintedEvent.Id,
 	})

--- a/integration-tests/modules/legacy_nft_assetnft_test.go
+++ b/integration-tests/modules/legacy_nft_assetnft_test.go
@@ -93,8 +93,7 @@ func TestAssetNFTMintLegacyNFTClient(t *testing.T) {
 	}, nftMintedEvent)
 
 	// check that token is present in the nft module
-	//nolint:staticcheck // we are testing deprecated handlers
-	nftRes, err := nftClient.NFT(ctx, &nft.QueryNFTRequest{
+	nftRes, err := nftClient.NFT(ctx, &nft.QueryNFTRequest{ //nolint:staticcheck // we are testing deprecated handlers
 		ClassId: classID,
 		Id:      nftMintedEvent.Id,
 	})
@@ -113,8 +112,7 @@ func TestAssetNFTMintLegacyNFTClient(t *testing.T) {
 	requireT.Equal(jsonData, data2.Data)
 
 	// check the owner
-	//nolint:staticcheck // we are testing deprecated handlers
-	ownerRes, err := nftClient.Owner(ctx, &nft.QueryOwnerRequest{
+	ownerRes, err := nftClient.Owner(ctx, &nft.QueryOwnerRequest{ //nolint:staticcheck // we are testing deprecated handlers
 		ClassId: classID,
 		Id:      nftMintedEvent.Id,
 	})
@@ -147,8 +145,7 @@ func TestAssetNFTMintLegacyNFTClient(t *testing.T) {
 	}, nftSentEvent)
 
 	// check new owner
-	//nolint:staticcheck // we are testing deprecated handlers
-	ownerRes, err = nftClient.Owner(ctx, &nft.QueryOwnerRequest{
+	ownerRes, err = nftClient.Owner(ctx, &nft.QueryOwnerRequest{ //nolint:staticcheck // we are testing deprecated handlers
 		ClassId: classID,
 		Id:      nftMintedEvent.Id,
 	})


### PR DESCRIPTION
# Description

This PR changes TestIBCCallFromSmartContract to start and stop cosmos relayer inside test.
We need this to fully remove Cosmos Relayer from crust because that is the only place where we need it.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/coreum/673)
<!-- Reviewable:end -->
