### PR TITLE
Delete `nolint:dupl` annotations in test files

### DIFF
--- a/integration-tests/modules/assetft_test.go
+++ b/integration-tests/modules/assetft_test.go
@@ -758,8 +758,6 @@ func TestAssetFTBurn(t *testing.T) {
 }
 
 // TestAssetFTBurnRate tests burn rate functionality of fungible tokens.
-//
-//nolint:dupl
 func TestAssetFTBurnRate(t *testing.T) {
 	t.Parallel()
 
@@ -905,8 +903,6 @@ func TestAssetFTBurnRate(t *testing.T) {
 }
 
 // TestAssetFTSendCommissionRate tests send commission rate functionality of fungible tokens.
-//
-//nolint:dupl
 func TestAssetFTSendCommissionRate(t *testing.T) {
 	t.Parallel()
 
@@ -1823,8 +1819,6 @@ func TestSendCoreTokenWithRestrictedToken(t *testing.T) {
 }
 
 // TestNotEnoughBalanceForBurnRate checks tx will fail if there is not enough balance to cover burn rate.
-//
-//nolint:dupl // we expect code duplication in tests
 func TestNotEnoughBalanceForBurnRate(t *testing.T) {
 	t.Parallel()
 
@@ -1902,8 +1896,6 @@ func TestNotEnoughBalanceForBurnRate(t *testing.T) {
 }
 
 // TestNotEnoughBalanceForCommissionRate checks tx will fail if there is not enough balance to cover commission rate.
-//
-//nolint:dupl // we expect code duplication in tests
 func TestNotEnoughBalanceForCommissionRate(t *testing.T) {
 	t.Parallel()
 

--- a/x/asset/ft/keeper/keeper_test.go
+++ b/x/asset/ft/keeper/keeper_test.go
@@ -511,7 +511,6 @@ func TestKeeper_Burn(t *testing.T) {
 	requireT.ErrorIs(err, cosmoserrors.ErrInsufficientFunds)
 }
 
-//nolint:dupl // We don't care
 func TestKeeper_BurnRate_BankSend(t *testing.T) {
 	requireT := require.New(t)
 
@@ -759,7 +758,6 @@ func TestKeeper_BurnRate_BankMultiSend(t *testing.T) {
 	}
 }
 
-//nolint:dupl // We don't care
 func TestKeeper_SendCommissionRate_BankSend(t *testing.T) {
 	requireT := require.New(t)
 

--- a/x/asset/ft/types/msgs_test.go
+++ b/x/asset/ft/types/msgs_test.go
@@ -305,7 +305,6 @@ func TestMsgUnfreeze_ValidateBasic(t *testing.T) {
 	}
 }
 
-//nolint:dupl // tests and mint tests are identical, but merging them is not beneficial
 func TestMsgMint_ValidateBasic(t *testing.T) {
 	type M = types.MsgMint
 
@@ -352,7 +351,6 @@ func TestMsgMint_ValidateBasic(t *testing.T) {
 	}
 }
 
-//nolint:dupl // tests and mint tests are identical, but merging them is not beneficial
 func TestMsgBurn_ValidateBasic(t *testing.T) {
 	type M = types.MsgBurn
 

--- a/x/asset/ft/types/token_test.go
+++ b/x/asset/ft/types/token_test.go
@@ -280,7 +280,6 @@ func TestValidateFeatures(t *testing.T) {
 	}
 }
 
-//nolint:dupl // We don't care
 func TestValidateBurnRate(t *testing.T) {
 	testCases := []struct {
 		rate    string
@@ -363,7 +362,6 @@ func TestValidateBurnRate(t *testing.T) {
 	}
 }
 
-//nolint:dupl // We don't care
 func TestValidateSendCommissionRate(t *testing.T) {
 	testCases := []struct {
 		rate    string

--- a/x/asset/nft/types/msgs_test.go
+++ b/x/asset/nft/types/msgs_test.go
@@ -324,7 +324,6 @@ func TestMsgMint_ValidateBasic(t *testing.T) {
 	}
 }
 
-//nolint:dupl // test case duplicates are ok
 func TestMsgBurn_ValidateBasic(t *testing.T) {
 	validMessage := types.MsgBurn{
 		Sender:  "devcore172rc5sz2uclpsy3vvx3y79ah5dk450z5ruq2r5",
@@ -386,7 +385,6 @@ func TestMsgBurn_ValidateBasic(t *testing.T) {
 	}
 }
 
-//nolint:dupl // test case duplicates are ok
 func TestMsgFreeze_ValidateBasic(t *testing.T) {
 	validMessage := types.MsgFreeze{
 		Sender:  "devcore172rc5sz2uclpsy3vvx3y79ah5dk450z5ruq2r5",
@@ -448,7 +446,6 @@ func TestMsgFreeze_ValidateBasic(t *testing.T) {
 	}
 }
 
-//nolint:dupl // test case duplicates are ok
 func TestMsgUnfreeze_ValidateBasic(t *testing.T) {
 	validMessage := types.MsgUnfreeze{
 		Sender:  "devcore172rc5sz2uclpsy3vvx3y79ah5dk450z5ruq2r5",
@@ -510,7 +507,6 @@ func TestMsgUnfreeze_ValidateBasic(t *testing.T) {
 	}
 }
 
-//nolint:dupl // test case duplicates are ok
 func TestMsgAddToWhitelist_ValidateBasic(t *testing.T) {
 	validMessage := types.MsgAddToWhitelist{
 		Sender:  "devcore172rc5sz2uclpsy3vvx3y79ah5dk450z5ruq2r5",
@@ -582,7 +578,6 @@ func TestMsgAddToWhitelist_ValidateBasic(t *testing.T) {
 	}
 }
 
-//nolint:dupl // test case duplicates are ok
 func TestMsgRemoveFromWhitelist_ValidateBasic(t *testing.T) {
 	validMessage := types.MsgRemoveFromWhitelist{
 		Sender:  "devcore172rc5sz2uclpsy3vvx3y79ah5dk450z5ruq2r5",


### PR DESCRIPTION
# Description

We disabled `dupl` linter for test files.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/coreum/686)
<!-- Reviewable:end -->
