### PR TITLE
Take data size into account when computing deterministic gas for NFT messages

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,6 @@
 - [ ] Try to write more meaningful comments with clear actions to be taken.
 - [ ] Nit-picking should be unblocking. Focus on core issues.
 
-
 # Authors checklist
 - [ ] Provide a concise and meaningful description
 - [ ] Review the code yourself first, before making the PR.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,7 @@
 - [ ] Try to write more meaningful comments with clear actions to be taken.
 - [ ] Nit-picking should be unblocking. Focus on core issues.
 
+
 # Authors checklist
 - [ ] Provide a concise and meaningful description
 - [ ] Review the code yourself first, before making the PR.

--- a/integration-tests/modules/assetnft_test.go
+++ b/integration-tests/modules/assetnft_test.go
@@ -51,72 +51,13 @@ func TestAssetNFTIssueClass(t *testing.T) {
 
 	assetNftClient := assetnfttypes.NewQueryClient(chain.ClientContext)
 
-	chain.FundAccountWithOptions(ctx, t, issuer, integration.BalancesOptions{
-		Messages: []sdk.Msg{
-			&assetnfttypes.MsgIssueClass{},
-		},
-	})
+	// prepare issue message
 
-	// issue new NFT class with invalid data type
-
-	data, err := codectypes.NewAnyWithValue(&assetnfttypes.MsgMint{})
+	jsonData := []byte(`{"name": "Name", "description": "Description"}`)
+	data, err := codectypes.NewAnyWithValue(&assetnfttypes.DataBytes{Data: jsonData})
 	requireT.NoError(err)
 
 	issueMsg := &assetnfttypes.MsgIssueClass{
-		Issuer:      issuer.String(),
-		Symbol:      "symbol",
-		Name:        "name",
-		Description: "description",
-		URI:         "https://my-class-meta.invalid/1",
-		URIHash:     "content-hash",
-		Data:        data,
-		Features: []assetnfttypes.ClassFeature{
-			assetnfttypes.ClassFeature_burning,
-		},
-	}
-	_, err = client.BroadcastTx(
-		ctx,
-		chain.ClientContext.WithFromAddress(issuer),
-		chain.TxFactory().WithGas(chain.GasLimitByMsgs(issueMsg)),
-		issueMsg,
-	)
-	requireT.True(assetnfttypes.ErrInvalidInput.Is(err))
-
-	// issue new NFT class with too long data
-
-	data, err = codectypes.NewAnyWithValue(&assetnfttypes.DataBytes{Data: bytes.Repeat([]byte{0x01}, assetnfttypes.MaxDataSize+1)})
-	requireT.NoError(err)
-
-	issueMsg = &assetnfttypes.MsgIssueClass{
-		Issuer:      issuer.String(),
-		Symbol:      "symbol",
-		Name:        "name",
-		Description: "description",
-		URI:         "https://my-class-meta.invalid/1",
-		URIHash:     "content-hash",
-		Data:        data,
-	}
-	_, err = client.BroadcastTx(
-		ctx,
-		chain.ClientContext.WithFromAddress(issuer),
-		chain.TxFactory().WithGas(chain.GasLimitByMsgs(issueMsg)),
-		issueMsg,
-	)
-	requireT.True(assetnfttypes.ErrInvalidInput.Is(err))
-
-	jsonData := []byte(`{"name": "Name", "description": "Description"}`)
-
-	// issue new NFT class
-	data, err = codectypes.NewAnyWithValue(&assetnfttypes.DataBytes{Data: jsonData})
-	requireT.NoError(err)
-
-	// we need to do this, otherwise assertion fails because some private fields are set differently
-	dataToCompare := &codectypes.Any{
-		TypeUrl: data.TypeUrl,
-		Value:   data.Value,
-	}
-
-	issueMsg = &assetnfttypes.MsgIssueClass{
 		Issuer:      issuer.String(),
 		Symbol:      "symbol",
 		Name:        "name",
@@ -130,6 +71,68 @@ func TestAssetNFTIssueClass(t *testing.T) {
 		},
 		RoyaltyRate: sdk.MustNewDecFromStr("0.1"),
 	}
+
+	chain.FundAccountWithOptions(ctx, t, issuer, integration.BalancesOptions{
+		Messages: []sdk.Msg{
+			issueMsg,
+		},
+	})
+
+	// issue new NFT class with invalid data type
+
+	invalidData, err := codectypes.NewAnyWithValue(&assetnfttypes.MsgMint{})
+	requireT.NoError(err)
+
+	invalidIssueMsg := &assetnfttypes.MsgIssueClass{
+		Issuer:      issuer.String(),
+		Symbol:      "symbol",
+		Name:        "name",
+		Description: "description",
+		URI:         "https://my-class-meta.invalid/1",
+		URIHash:     "content-hash",
+		Data:        invalidData,
+		Features: []assetnfttypes.ClassFeature{
+			assetnfttypes.ClassFeature_burning,
+		},
+	}
+	_, err = client.BroadcastTx(
+		ctx,
+		chain.ClientContext.WithFromAddress(issuer),
+		chain.TxFactory().WithGas(chain.GasLimitByMsgs(invalidIssueMsg)),
+		invalidIssueMsg,
+	)
+	requireT.True(assetnfttypes.ErrInvalidInput.Is(err))
+
+	// issue new NFT class with too long data
+
+	invalidData, err = codectypes.NewAnyWithValue(&assetnfttypes.DataBytes{Data: bytes.Repeat([]byte{0x01}, assetnfttypes.MaxDataSize+1)})
+	requireT.NoError(err)
+
+	invalidIssueMsg = &assetnfttypes.MsgIssueClass{
+		Issuer:      issuer.String(),
+		Symbol:      "symbol",
+		Name:        "name",
+		Description: "description",
+		URI:         "https://my-class-meta.invalid/1",
+		URIHash:     "content-hash",
+		Data:        invalidData,
+	}
+	_, err = client.BroadcastTx(
+		ctx,
+		chain.ClientContext.WithFromAddress(issuer),
+		chain.TxFactory().WithGas(chain.GasLimitByMsgs(invalidIssueMsg)),
+		invalidIssueMsg,
+	)
+	requireT.True(assetnfttypes.ErrInvalidInput.Is(err))
+
+	// issue new NFT class
+
+	// we need to do this, otherwise assertion fails because some private fields are set differently
+	dataToCompare := &codectypes.Any{
+		TypeUrl: data.TypeUrl,
+		Value:   data.Value,
+	}
+
 	res, err := client.BroadcastTx(
 		ctx,
 		chain.ClientContext.WithFromAddress(issuer),
@@ -356,11 +359,24 @@ func TestAssetNFTMint(t *testing.T) {
 	issuer := chain.GenAccount()
 	recipient := chain.GenAccount()
 
+	// prepare mint message
+	jsonData := []byte(`{"name": "Name", "description": "Description"}`)
+	data, err := codectypes.NewAnyWithValue(&assetnfttypes.DataBytes{Data: jsonData})
+	requireT.NoError(err)
+
+	mintMsg := &assetnfttypes.MsgMint{
+		Sender:  issuer.String(),
+		ID:      "id-1",
+		URI:     "https://my-class-meta.invalid/1",
+		URIHash: "content-hash",
+		Data:    data,
+	}
+
 	nftClient := nft.NewQueryClient(chain.ClientContext)
 	chain.FundAccountWithOptions(ctx, t, issuer, integration.BalancesOptions{
 		Messages: []sdk.Msg{
 			&assetnfttypes.MsgIssueClass{},
-			&assetnfttypes.MsgMint{},
+			mintMsg,
 			&nft.MsgSend{},
 			&assetnfttypes.MsgMint{},
 		},
@@ -372,7 +388,7 @@ func TestAssetNFTMint(t *testing.T) {
 		Issuer: issuer.String(),
 		Symbol: "NFTClassSymbol",
 	}
-	_, err := client.BroadcastTx(
+	_, err = client.BroadcastTx(
 		ctx,
 		chain.ClientContext.WithFromAddress(issuer),
 		chain.TxFactory().WithGas(chain.GasLimitByMsgs(issueMsg)),
@@ -384,51 +400,47 @@ func TestAssetNFTMint(t *testing.T) {
 
 	// mint with invalid data type
 
-	data, err := codectypes.NewAnyWithValue(&assetnfttypes.MsgMint{})
+	invalidData, err := codectypes.NewAnyWithValue(&assetnfttypes.MsgMint{})
 	requireT.NoError(err)
 
-	mintMsg := &assetnfttypes.MsgMint{
+	invalidMintMsg := &assetnfttypes.MsgMint{
 		Sender:  issuer.String(),
 		ID:      "id-1",
 		ClassID: classID,
 		URI:     "https://my-class-meta.invalid/1",
 		URIHash: "content-hash",
-		Data:    data,
+		Data:    invalidData,
 	}
 	_, err = client.BroadcastTx(
 		ctx,
 		chain.ClientContext.WithFromAddress(issuer),
-		chain.TxFactory().WithGas(chain.GasLimitByMsgs(mintMsg)),
-		mintMsg,
+		chain.TxFactory().WithGas(chain.GasLimitByMsgs(invalidMintMsg)),
+		invalidMintMsg,
 	)
 	requireT.True(assetnfttypes.ErrInvalidInput.Is(err))
 
 	// mint with too long data
 
-	data, err = codectypes.NewAnyWithValue(&assetnfttypes.DataBytes{Data: bytes.Repeat([]byte{0x01}, assetnfttypes.MaxDataSize+1)})
+	invalidData, err = codectypes.NewAnyWithValue(&assetnfttypes.DataBytes{Data: bytes.Repeat([]byte{0x01}, assetnfttypes.MaxDataSize+1)})
 	requireT.NoError(err)
 
-	mintMsg = &assetnfttypes.MsgMint{
+	invalidMintMsg = &assetnfttypes.MsgMint{
 		Sender:  issuer.String(),
 		ID:      "id-1",
 		ClassID: classID,
 		URI:     "https://my-class-meta.invalid/1",
 		URIHash: "content-hash",
-		Data:    data,
+		Data:    invalidData,
 	}
 	_, err = client.BroadcastTx(
 		ctx,
 		chain.ClientContext.WithFromAddress(issuer),
-		chain.TxFactory().WithGas(chain.GasLimitByMsgs(mintMsg)),
-		mintMsg,
+		chain.TxFactory().WithGas(chain.GasLimitByMsgs(invalidMintMsg)),
+		invalidMintMsg,
 	)
 	requireT.True(assetnfttypes.ErrInvalidInput.Is(err))
 
-	jsonData := []byte(`{"name": "Name", "description": "Description"}`)
-
 	// mint new token in that class
-	data, err = codectypes.NewAnyWithValue(&assetnfttypes.DataBytes{Data: jsonData})
-	requireT.NoError(err)
 
 	// we need to do this, otherwise assertion fails because some private fields are set differently
 	dataToCompare := &codectypes.Any{
@@ -436,14 +448,7 @@ func TestAssetNFTMint(t *testing.T) {
 		Value:   data.Value,
 	}
 
-	mintMsg = &assetnfttypes.MsgMint{
-		Sender:  issuer.String(),
-		ID:      "id-1",
-		ClassID: classID,
-		URI:     "https://my-class-meta.invalid/1",
-		URIHash: "content-hash",
-		Data:    data,
-	}
+	mintMsg.ClassID = classID
 	res, err := client.BroadcastTx(
 		ctx,
 		chain.ClientContext.WithFromAddress(issuer),

--- a/integration-tests/upgrade/nft_migration_test.go
+++ b/integration-tests/upgrade/nft_migration_test.go
@@ -31,15 +31,6 @@ func (nut *nftMigrationTest) Before(t *testing.T) {
 
 	issuer := chain.GenAccount()
 	nut.issuer = issuer
-	chain.FundAccountWithOptions(ctx, t, issuer, integration.BalancesOptions{
-		Messages: []sdk.Msg{
-			&assetnfttypes.MsgIssueClass{},
-			&assetnfttypes.MsgIssueClass{},
-			&assetnfttypes.MsgMint{},
-			&assetnfttypes.MsgMint{},
-		},
-		Amount: chain.QueryAssetNFTParams(ctx, t).MintFee.Amount,
-	})
 
 	// issue nft class and mint nfts
 	jsonData := []byte(`{"name": "Name", "description": "Description"}`)
@@ -75,6 +66,11 @@ func (nut *nftMigrationTest) Before(t *testing.T) {
 			Data:    data,
 		},
 	}
+
+	chain.FundAccountWithOptions(ctx, t, issuer, integration.BalancesOptions{
+		Messages: issueAndMint,
+		Amount:   chain.QueryAssetNFTParams(ctx, t).MintFee.Amount,
+	})
 
 	_, err = client.BroadcastTx(
 		ctx,

--- a/x/deterministicgas/config.go
+++ b/x/deterministicgas/config.go
@@ -38,8 +38,8 @@ const (
 	BankSendPerCoinGas            = 50000
 	BankMultiSendPerOperationsGas = 35000
 	AuthzExecOverhead             = 1500
-	NFTMsgIssueClassCost          = 16_000
-	NFTMsgMintCost                = 39_000
+	NFTIssueClassBaseGas          = 16_000
+	NFTMintBaseGas                = 39_000
 )
 
 type (
@@ -87,8 +87,8 @@ func DefaultConfig() Config {
 
 		// asset/nft
 		MsgToMsgURL(&assetnfttypes.MsgBurn{}):                     constantGasFunc(26_000),
-		MsgToMsgURL(&assetnfttypes.MsgIssueClass{}):               dataGasFunc(NFTMsgIssueClassCost),
-		MsgToMsgURL(&assetnfttypes.MsgMint{}):                     dataGasFunc(NFTMsgMintCost),
+		MsgToMsgURL(&assetnfttypes.MsgIssueClass{}):               dataGasFunc(NFTIssueClassBaseGas),
+		MsgToMsgURL(&assetnfttypes.MsgMint{}):                     dataGasFunc(NFTMintBaseGas),
 		MsgToMsgURL(&assetnfttypes.MsgFreeze{}):                   constantGasFunc(8_000),
 		MsgToMsgURL(&assetnfttypes.MsgUnfreeze{}):                 constantGasFunc(5_000),
 		MsgToMsgURL(&assetnfttypes.MsgClassFreeze{}):              constantGasFunc(8_000),
@@ -372,13 +372,7 @@ func dataGasFunc(constGas uint64) gasByMsgFunc {
 		}
 
 		storeConfig := storetypes.KVGasConfig()
-
-		gas := uint64(dataLen)*storeConfig.WriteCostPerByte + constGas
-		if dataLen > 0 {
-			gas += storeConfig.WriteCostFlat
-		}
-
-		return gas, true
+		return uint64(dataLen)*storeConfig.WriteCostPerByte + constGas, true
 	}
 }
 

--- a/x/deterministicgas/config.go
+++ b/x/deterministicgas/config.go
@@ -38,6 +38,8 @@ const (
 	BankSendPerCoinGas            = 50000
 	BankMultiSendPerOperationsGas = 35000
 	AuthzExecOverhead             = 1500
+	NFTMsgIssueClassCost          = 16_000
+	NFTMsgMintCost                = 39_000
 )
 
 type (
@@ -85,8 +87,8 @@ func DefaultConfig() Config {
 
 		// asset/nft
 		MsgToMsgURL(&assetnfttypes.MsgBurn{}):                     constantGasFunc(26_000),
-		MsgToMsgURL(&assetnfttypes.MsgIssueClass{}):               dataGasFunc(16_000),
-		MsgToMsgURL(&assetnfttypes.MsgMint{}):                     dataGasFunc(39_000),
+		MsgToMsgURL(&assetnfttypes.MsgIssueClass{}):               dataGasFunc(NFTMsgIssueClassCost),
+		MsgToMsgURL(&assetnfttypes.MsgMint{}):                     dataGasFunc(NFTMsgMintCost),
 		MsgToMsgURL(&assetnfttypes.MsgFreeze{}):                   constantGasFunc(8_000),
 		MsgToMsgURL(&assetnfttypes.MsgUnfreeze{}):                 constantGasFunc(5_000),
 		MsgToMsgURL(&assetnfttypes.MsgClassFreeze{}):              constantGasFunc(8_000),

--- a/x/deterministicgas/spec/README.md
+++ b/x/deterministicgas/spec/README.md
@@ -38,6 +38,8 @@ Currently, we have values for the above variables as follows:
 - `TxSizeCostPerByte`: 10
 - `FreeSignatures`: 1
 - `FreeBytes`: 2048
+- `WriteCostPerByte`: 30
+- `WriteCostFlat`: 2000
 
 
 To summarize user pays FixedGas as long as `GasForBytes + GasForSignatures <= TxBaseGas`.
@@ -73,6 +75,8 @@ TotalGas = 65000 +  max(0, (21480 - 2 * 1000 + 2050 * 10)) + 2 * 70000
 
 | Message Type | Gas |
 |--------------|-----|
+| `/coreum.asset.nft.v1.MsgIssueClass`                                   | [special case](#special-cases) |
+| `/coreum.asset.nft.v1.MsgMint`                                         | [special case](#special-cases) |
 | `/cosmos.authz.v1beta1.MsgExec`                                        | [special case](#special-cases) |
 | `/cosmos.bank.v1beta1.MsgMultiSend`                                    | [special case](#special-cases) |
 | `/cosmos.bank.v1beta1.MsgSend`                                         | [special case](#special-cases) |
@@ -92,8 +96,6 @@ TotalGas = 65000 +  max(0, (21480 - 2 * 1000 + 2050 * 10)) + 2 * 70000
 | `/coreum.asset.nft.v1.MsgClassFreeze`                                  | 8000                           |
 | `/coreum.asset.nft.v1.MsgClassUnfreeze`                                | 5000                           |
 | `/coreum.asset.nft.v1.MsgFreeze`                                       | 8000                           |
-| `/coreum.asset.nft.v1.MsgIssueClass`                                   | 16000                          |
-| `/coreum.asset.nft.v1.MsgMint`                                         | 39000                          |
 | `/coreum.asset.nft.v1.MsgRemoveFromClassWhitelist`                     | 3500                           |
 | `/coreum.asset.nft.v1.MsgRemoveFromWhitelist`                          | 3500                           |
 | `/coreum.asset.nft.v1.MsgUnfreeze`                                     | 5000                           |
@@ -160,6 +162,20 @@ Real examples of special case tests could be found [here](https://github.com/Cor
 `DeterministicGasForMsg = authzMsgExecOverhead + Sum(DeterministicGas(ChildMsg))`
 
 `authzMsgExecOverhead` is currently equal to `1500`.
+
+##### `/coreum.asset.nft.v1.MsgIssueClass`
+
+`DeterministicGasForMsg = msgGas + Len(msg.Data) * WriteCostPerByte + WriteCostFlat`
+
+`WriteCostFlat` is added only if `Len(msg.Data)` is positive.
+`msgGas` is currently equal to `16000`.
+
+##### `/coreum.asset.nft.v1.MsgMint`
+
+`DeterministicGasForMsg = msgGas + Len(msg.Data) * WriteCostPerByte + WriteCostFlat`
+
+`WriteCostFlat` is added only if `Len(msg.Data)` is positive.
+`msgGas` is currently equal to `39000`.
 
 ### Nondeterministic messages
 

--- a/x/deterministicgas/spec/README.md
+++ b/x/deterministicgas/spec/README.md
@@ -39,8 +39,6 @@ Currently, we have values for the above variables as follows:
 - `FreeSignatures`: 1
 - `FreeBytes`: 2048
 - `WriteCostPerByte`: 30
-- `WriteCostFlat`: 2000
-
 
 To summarize user pays FixedGas as long as `GasForBytes + GasForSignatures <= TxBaseGas`.
 If `GasForBytes + GasForSignatures > TxBaseGas` user will have to pay anything above `TxBaseGas` on top of `FixedGas`. 
@@ -165,16 +163,14 @@ Real examples of special case tests could be found [here](https://github.com/Cor
 
 ##### `/coreum.asset.nft.v1.MsgIssueClass`
 
-`DeterministicGasForMsg = msgGas + Len(msg.Data) * WriteCostPerByte + WriteCostFlat`
+`DeterministicGasForMsg = msgGas + Len(msg.Data) * WriteCostPerByte`
 
-`WriteCostFlat` is added only if `Len(msg.Data)` is positive.
 `msgGas` is currently equal to `16000`.
 
 ##### `/coreum.asset.nft.v1.MsgMint`
 
-`DeterministicGasForMsg = msgGas + Len(msg.Data) * WriteCostPerByte + WriteCostFlat`
+`DeterministicGasForMsg = msgGas + Len(msg.Data) * WriteCostPerByte`
 
-`WriteCostFlat` is added only if `Len(msg.Data)` is positive.
 `msgGas` is currently equal to `39000`.
 
 ### Nondeterministic messages

--- a/x/deterministicgas/spec/README.tmpl.md
+++ b/x/deterministicgas/spec/README.tmpl.md
@@ -37,6 +37,8 @@ Currently, we have values for the above variables as follows:
 - `TxSizeCostPerByte`: {{ .TxSizeCostPerByte }}
 - `FreeSignatures`: {{ .FreeSignatures }}
 - `FreeBytes`: {{ .FreeBytes }}
+- `WriteCostPerByte`: {{ .WriteCostPerByte }}
+- `WriteCostFlat`: {{ .WriteCostFlat }}
 
 
 To summarize user pays FixedGas as long as `GasForBytes + GasForSignatures <= TxBaseGas`.
@@ -101,6 +103,20 @@ Real examples of special case tests could be found [here](https://github.com/Cor
 `DeterministicGasForMsg = authzMsgExecOverhead + Sum(DeterministicGas(ChildMsg))`
 
 `authzMsgExecOverhead` is currently equal to `{{ .AuthzExecOverhead }}`.
+
+##### `/coreum.asset.nft.v1.MsgIssueClass`
+
+`DeterministicGasForMsg = msgGas + Len(msg.Data) * WriteCostPerByte + WriteCostFlat`
+
+`WriteCostFlat` is added only if `Len(msg.Data)` is positive.
+`msgGas` is currently equal to `{{ .NFTMsgIssueClassCost }}`.
+
+##### `/coreum.asset.nft.v1.MsgMint`
+
+`DeterministicGasForMsg = msgGas + Len(msg.Data) * WriteCostPerByte + WriteCostFlat`
+
+`WriteCostFlat` is added only if `Len(msg.Data)` is positive.
+`msgGas` is currently equal to `{{ .NFTMsgMintCost }}`.
 
 ### Nondeterministic messages
 

--- a/x/deterministicgas/spec/README.tmpl.md
+++ b/x/deterministicgas/spec/README.tmpl.md
@@ -38,8 +38,6 @@ Currently, we have values for the above variables as follows:
 - `FreeSignatures`: {{ .FreeSignatures }}
 - `FreeBytes`: {{ .FreeBytes }}
 - `WriteCostPerByte`: {{ .WriteCostPerByte }}
-- `WriteCostFlat`: {{ .WriteCostFlat }}
-
 
 To summarize user pays FixedGas as long as `GasForBytes + GasForSignatures <= TxBaseGas`.
 If `GasForBytes + GasForSignatures > TxBaseGas` user will have to pay anything above `TxBaseGas` on top of `FixedGas`. 
@@ -106,16 +104,14 @@ Real examples of special case tests could be found [here](https://github.com/Cor
 
 ##### `/coreum.asset.nft.v1.MsgIssueClass`
 
-`DeterministicGasForMsg = msgGas + Len(msg.Data) * WriteCostPerByte + WriteCostFlat`
+`DeterministicGasForMsg = msgGas + Len(msg.Data) * WriteCostPerByte`
 
-`WriteCostFlat` is added only if `Len(msg.Data)` is positive.
 `msgGas` is currently equal to `{{ .NFTMsgIssueClassCost }}`.
 
 ##### `/coreum.asset.nft.v1.MsgMint`
 
-`DeterministicGasForMsg = msgGas + Len(msg.Data) * WriteCostPerByte + WriteCostFlat`
+`DeterministicGasForMsg = msgGas + Len(msg.Data) * WriteCostPerByte`
 
-`WriteCostFlat` is added only if `Len(msg.Data)` is positive.
 `msgGas` is currently equal to `{{ .NFTMsgMintCost }}`.
 
 ### Nondeterministic messages

--- a/x/deterministicgas/spec/generate.go
+++ b/x/deterministicgas/spec/generate.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"text/template"
 
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	auth "github.com/cosmos/cosmos-sdk/x/auth/types"
 
 	assetfttypes "github.com/CoreumFoundation/coreum/v3/x/asset/ft/types"
@@ -74,6 +75,7 @@ func main() {
 	}
 
 	authParams := auth.DefaultParams()
+	storeConfig := storetypes.KVGasConfig()
 	err = template.Must(template.New("README.md").Parse(readmeTmpl)).Execute(file, struct {
 		GeneratorComment  string
 		SigVerifyCost     uint64
@@ -82,11 +84,15 @@ func main() {
 		TxBaseGas         uint64
 		FreeBytes         uint64
 		FreeSignatures    uint64
+		WriteCostPerByte  uint64
+		WriteCostFlat     uint64
 
 		MsgIssueGasPrice              uint64
 		BankSendPerCoinGas            uint64
 		BankMultiSendPerOperationsGas uint64
 		AuthzExecOverhead             uint64
+		NFTMsgIssueClassCost          uint64
+		NFTMsgMintCost                uint64
 
 		DetermMsgsSpecialCases []deterministicgas.MsgURL
 		DetermMsgs             []determMsg
@@ -102,11 +108,15 @@ func main() {
 		TxSizeCostPerByte: authParams.TxSizeCostPerByte,
 		FreeBytes:         cfg.FreeBytes,
 		FreeSignatures:    cfg.FreeSignatures,
+		WriteCostPerByte:  storeConfig.WriteCostPerByte,
+		WriteCostFlat:     storeConfig.WriteCostFlat,
 
 		MsgIssueGasPrice:              msgIssueGasPrice,
 		BankSendPerCoinGas:            deterministicgas.BankSendPerCoinGas,
 		BankMultiSendPerOperationsGas: deterministicgas.BankMultiSendPerOperationsGas,
 		AuthzExecOverhead:             deterministicgas.AuthzExecOverhead,
+		NFTMsgIssueClassCost:          deterministicgas.NFTMsgIssueClassCost,
+		NFTMsgMintCost:                deterministicgas.NFTMsgMintCost,
 
 		DetermMsgsSpecialCases: determSpeicialCaseMsgURLs,
 		DetermMsgs:             determMsgs,

--- a/x/deterministicgas/spec/generate.go
+++ b/x/deterministicgas/spec/generate.go
@@ -86,7 +86,6 @@ func main() {
 		FreeBytes         uint64
 		FreeSignatures    uint64
 		WriteCostPerByte  uint64
-		WriteCostFlat     uint64
 
 		MsgIssueGasPrice              uint64
 		BankSendPerCoinGas            uint64
@@ -110,14 +109,13 @@ func main() {
 		FreeBytes:         cfg.FreeBytes,
 		FreeSignatures:    cfg.FreeSignatures,
 		WriteCostPerByte:  storeConfig.WriteCostPerByte,
-		WriteCostFlat:     storeConfig.WriteCostFlat,
 
 		MsgIssueGasPrice:              msgIssueGasPrice,
 		BankSendPerCoinGas:            deterministicgas.BankSendPerCoinGas,
 		BankMultiSendPerOperationsGas: deterministicgas.BankMultiSendPerOperationsGas,
 		AuthzExecOverhead:             deterministicgas.AuthzExecOverhead,
-		NFTMsgIssueClassCost:          deterministicgas.NFTMsgIssueClassCost,
-		NFTMsgMintCost:                deterministicgas.NFTMsgMintCost,
+		NFTMsgIssueClassCost:          deterministicgas.NFTIssueClassBaseGas,
+		NFTMsgMintCost:                deterministicgas.NFTMintBaseGas,
 
 		DetermMsgsSpecialCases: determSpeicialCaseMsgURLs,
 		DetermMsgs:             determMsgs,

--- a/x/deterministicgas/spec/generate.go
+++ b/x/deterministicgas/spec/generate.go
@@ -21,6 +21,7 @@ import (
 //go:embed README.tmpl.md
 var readmeTmpl string
 
+//nolint:funlen
 func main() {
 	type determMsg struct {
 		Type deterministicgas.MsgURL


### PR DESCRIPTION
# Description

If large data chunk is provided constant deterministic gas might be exceeded. To fix this, we compute deterministic gas based on the data length.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [ ] Provide a concise and meaningful description
- [ ] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/coreum/718)
<!-- Reviewable:end -->
