### PR TITLE
Don't await transaction in dry run mode

### DIFF
--- a/cmd/cored/cosmoscmd/root.go
+++ b/cmd/cored/cosmoscmd/root.go
@@ -310,6 +310,7 @@ func installAwaitBroadcastModeWrapper(cmd *cobra.Command) {
 	flagSet.ParseErrorsWhitelist.UnknownFlags = true
 	broadcastMode := flagSet.StringP(flags.FlagBroadcastMode, "b", "", "")
 	originalOutputFormat := flagSet.StringP(flags.FlagOutput, "o", "", "")
+	dryRun := flagSet.Bool(flags.FlagDryRun, false, "")
 	// Dummy flag to turn off printing usage of this flag set
 	flagSet.BoolP(flagHelp, "h", false, "")
 	//nolint:errcheck // since we have set ExitOnError on flagset, we don't need to check for errors here
@@ -323,9 +324,12 @@ func installAwaitBroadcastModeWrapper(cmd *cobra.Command) {
 	// wrapper behaves correctly.
 	if *broadcastMode == broadcastModeBlock {
 		removeFlag(os.Args, "-b")
-		removeFlag(os.Args, "-o")
 		os.Args = append(removeFlag(os.Args, "--"+flags.FlagBroadcastMode), "--"+flags.FlagBroadcastMode, flags.BroadcastSync)
-		os.Args = append(removeFlag(os.Args, "--"+flags.FlagOutput), "--"+flags.FlagOutput, "json")
+
+		if !*dryRun {
+			removeFlag(os.Args, "-o")
+			os.Args = append(removeFlag(os.Args, "--"+flags.FlagOutput), "--"+flags.FlagOutput, "json")
+		}
 	}
 
 	// Iterate over all the "tx" subcommands.
@@ -340,8 +344,8 @@ func installAwaitBroadcastModeWrapper(cmd *cobra.Command) {
 			broadcastModeFlag.Usage = `Transaction broadcasting mode (sync|async|block)`
 		}
 
-		// We install our wrapper only if this is "block" broadcast mode.
-		if *broadcastMode != broadcastModeBlock {
+		// We install our wrapper only if this is "block" broadcast mode and not a dry run.
+		if *broadcastMode != broadcastModeBlock || *dryRun {
 			continue
 		}
 


### PR DESCRIPTION
# Description

If `--dry-run` flag is set, transaction is not stored, so there is nothing to await.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/coreum/722)
<!-- Reviewable:end -->
