### PR TITLE
Increase upgrade delay in blocks & fix hardcoded timeout in legacy gov

### DIFF
--- a/integration-tests/upgrade/upgrade_test.go
+++ b/integration-tests/upgrade/upgrade_test.go
@@ -25,6 +25,11 @@ import (
 	"github.com/CoreumFoundation/coreum/v4/testutil/integration"
 )
 
+// Proper value for upgradeDelayInBlocks depends on block time and gov voting period.
+// upgradeDelayInBlocks*blockTime >= govVotingPeriod
+// Current value for govVotingPeriod is 20s and blockTime is customizable by flag and varies between 0.5s and 1s.
+const upgradeDelayInBlocks = 50
+
 type upgradeTest interface {
 	Before(t *testing.T)
 	After(t *testing.T)
@@ -56,7 +61,7 @@ func upgradeV3ToV4(t *testing.T) {
 		test.Before(t)
 	}
 
-	runUpgrade(t, appupgradev4.Name, 30)
+	runUpgrade(t, appupgradev4.Name, upgradeDelayInBlocks)
 
 	for _, test := range tests {
 		test.After(t)
@@ -64,7 +69,7 @@ func upgradeV3ToV4(t *testing.T) {
 }
 
 func upgradeV2ToV3(t *testing.T) {
-	runLegacyUpgrade(t, appupgradev3.Name, 30)
+	runLegacyUpgrade(t, appupgradev3.Name, upgradeDelayInBlocks)
 }
 
 func runUpgrade(

--- a/testutil/integration/gov_legacy.go
+++ b/testutil/integration/gov_legacy.go
@@ -286,7 +286,11 @@ func (g GovernanceLegacy) WaitForVotingToFinalize(
 		}
 	}
 
-	retryCtx, retryCancel := context.WithTimeout(ctx, 10*time.Second)
+	params, err := g.QueryGovParams(ctx)
+	if err != nil {
+		return proposal.Status, err
+	}
+	retryCtx, retryCancel := context.WithTimeout(ctx, params.VotingParams.VotingPeriod)
 	defer retryCancel()
 
 	err = retry.Do(retryCtx, time.Second, func() error {


### PR DESCRIPTION
# Description

upgrade delay in blocks had to be increased because voting time is 20s now

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [ ] Provide a concise and meaningful description
- [ ] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.
