### PR TITLE
Change order of tests in upgrade test to upgrade -> IBC -> modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,9 @@ jobs:
             command: |
               coreum-builder build images
               crust znet start --cored-version=v3.0.2 --profiles=3cored,ibc --timeout-commit 1s
-              coreum-builder integration-tests-unsafe/upgrade integration-tests-unsafe/modules integration-tests-unsafe/ibc
+              coreum-builder integration-tests-unsafe/upgrade integration-tests-unsafe/modules
+              sleep 30
+              coreum-builder integration-tests-unsafe/ibc
             linter-cache: false
             codecov: false
           - ci_step: "integration tests faucet"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
             command: |
               coreum-builder build images
               crust znet start --cored-version=v3.0.2 --profiles=3cored,ibc --timeout-commit 1s
-              coreum-builder integration-tests-unsafe/upgrade integration-tests-unsafe/modules integration-tests-unsafe/ibc
+              coreum-builder integration-tests-unsafe/upgrade integration-tests-unsafe/ibc
             linter-cache: false
             codecov: false
           - ci_step: "integration tests faucet"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,10 @@ jobs:
             linter-cache: false
             codecov: false
           - ci_step: "integration tests coreum-upgrade-v4.0.0"
-            # TODO(yaroslav): Return back IBC tests.
             command: |
               coreum-builder build images
               crust znet start --cored-version=v3.0.2 --profiles=3cored,ibc --timeout-commit 1s
-              coreum-builder integration-tests-unsafe/upgrade integration-tests-unsafe/ibc
+              coreum-builder integration-tests-unsafe/upgrade integration-tests-unsafe/ibc integration-tests-unsafe/modules
             linter-cache: false
             codecov: false
           - ci_step: "integration tests faucet"
@@ -84,7 +83,6 @@ jobs:
         with:
           repository: CoreumFoundation/crust
           path: crust
-          ref: "57f3800c540843690f96bb6d913818264aff5b2e"
       - name: Set up build system
         run: |
           echo "$(pwd)/coreum/bin" >> $GITHUB_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
             command: |
               coreum-builder build images
               crust znet start --profiles=3cored,ibc --timeout-commit 1s
-              coreum-builder integration-tests-unsafe/modules integration-tests-unsafe/ibc
+              coreum-builder integration-tests-unsafe/ibc
             linter-cache: false
             codecov: false
           - ci_step: "integration tests coreum-upgrade-v4.0.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,7 @@ jobs:
             command: |
               coreum-builder build images
               crust znet start --cored-version=v3.0.2 --profiles=3cored,ibc --timeout-commit 1s
-              coreum-builder integration-tests-unsafe/upgrade integration-tests-unsafe/modules
-              sleep 30
-              coreum-builder integration-tests-unsafe/ibc
+              coreum-builder integration-tests-unsafe/upgrade integration-tests-unsafe/modules integration-tests-unsafe/ibc
             linter-cache: false
             codecov: false
           - ci_step: "integration tests faucet"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           repository: CoreumFoundation/crust
           path: crust
-          ref: "yaroslav/clear-packets"
+          ref: "57f3800"
       - name: Set up build system
         run: |
           echo "$(pwd)/coreum/bin" >> $GITHUB_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           repository: CoreumFoundation/crust
           path: crust
-          ref: "57f3800"
+          ref: "57f3800c540843690f96bb6d913818264aff5b2e"
       - name: Set up build system
         run: |
           echo "$(pwd)/coreum/bin" >> $GITHUB_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
             command: |
               coreum-builder build images
               crust znet start --profiles=3cored,ibc --timeout-commit 1s
-              coreum-builder integration-tests-unsafe/ibc
+              coreum-builder integration-tests-unsafe/modules integration-tests-unsafe/ibc
             linter-cache: false
             codecov: false
           - ci_step: "integration tests coreum-upgrade-v4.0.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
             command: |
               coreum-builder build images
               crust znet start --cored-version=v3.0.2 --profiles=3cored,ibc --timeout-commit 1s
-              coreum-builder integration-tests-unsafe/upgrade integration-tests-unsafe/modules
+              coreum-builder integration-tests-unsafe/upgrade integration-tests-unsafe/modules integration-tests-unsafe/ibc
             linter-cache: false
             codecov: false
           - ci_step: "integration tests faucet"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
         with:
           repository: CoreumFoundation/crust
           path: crust
+          ref: "yaroslav/clear-packets"
       - name: Set up build system
         run: |
           echo "$(pwd)/coreum/bin" >> $GITHUB_PATH

--- a/testutil/integration/chain_ibc.go
+++ b/testutil/integration/chain_ibc.go
@@ -24,7 +24,7 @@ import (
 )
 
 // AwaitForBalanceTimeout is duration to await for account to have a specific balance.
-var AwaitForBalanceTimeout = 2 * time.Minute
+var AwaitForBalanceTimeout = 30 * time.Second
 
 // ExecuteIBCTransfer executes IBC transfer transaction.
 func (c ChainContext) ExecuteIBCTransfer(

--- a/testutil/integration/chain_ibc.go
+++ b/testutil/integration/chain_ibc.go
@@ -24,7 +24,7 @@ import (
 )
 
 // AwaitForBalanceTimeout is duration to await for account to have a specific balance.
-var AwaitForBalanceTimeout = 30 * time.Second
+var AwaitForBalanceTimeout = 2 * time.Minute
 
 // ExecuteIBCTransfer executes IBC transfer transaction.
 func (c ChainContext) ExecuteIBCTransfer(


### PR DESCRIPTION
# Description

In `integration tests coreum-upgrade-v4.0.0` I changed the order of test.
Now: upgrade -> IBC -> modules
Before: upgrade -> modules -> IBC
This way CI doesn't fail. It turned out that running modules before IBC causes IBC to fail.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/coreum/806)
<!-- Reviewable:end -->
