### PR TITLE
Handle send commisson rate in extension

### DIFF
--- a/integration-tests/modules/assetft_extension_test.go
+++ b/integration-tests/modules/assetft_extension_test.go
@@ -1487,15 +1487,13 @@ func TestAssetFTExtensionBurnRate(t *testing.T) {
 		Amount:      sdk.NewCoins(sdk.NewCoin(denom, sdkmath.NewInt(400))),
 	}
 
-	txRes, err := client.BroadcastTx(
+	_, err = client.BroadcastTx(
 		ctx,
 		chain.ClientContext.WithFromAddress(admin),
 		chain.TxFactory().WithGas(chain.GasLimitByMsgs(sendMsg)),
 		sendMsg,
 	)
 	requireT.NoError(err)
-	// assert that we don't receive events with empty amounts
-	requireT.NotContains(txRes.RawLog, `{"key":"amount"}`)
 
 	assertCoinDistribution(ctx, chain.ClientContext, t, denom, map[*sdk.AccAddress]int64{
 		&admin:      560, // 1000 - 400 - 40 (10% burn rate)
@@ -1643,15 +1641,13 @@ func TestAssetFTExtensionSendCommissionRate(t *testing.T) {
 		Amount:      sdk.NewCoins(sdk.NewCoin(denom, sdkmath.NewInt(400))),
 	}
 
-	txRes, err := client.BroadcastTx(
+	_, err = client.BroadcastTx(
 		ctx,
 		chain.ClientContext.WithFromAddress(admin),
 		chain.TxFactory().WithGas(chain.GasLimitByMsgs(sendMsg)),
 		sendMsg,
 	)
 	requireT.NoError(err)
-	// assert that we don't receive events with empty amounts
-	requireT.NotContains(txRes.RawLog, `{"key":"amount"}`)
 
 	assertCoinDistribution(ctx, chain.ClientContext, t, denom, map[*sdk.AccAddress]int64{
 		&admin:      580, // 1000 - 400 - 40 (10% commission from sender) + 20 (50% of the commission to the admin)

--- a/integration-tests/modules/assetft_extension_test.go
+++ b/integration-tests/modules/assetft_extension_test.go
@@ -1701,7 +1701,7 @@ func TestAssetFTExtensionSendCommissionRate(t *testing.T) {
 		&extension:  25,
 	})
 
-	// send from recipient2 to admin (send commission rate must not apply)
+	// send from recipient2 to admin (send commission rate must apply if the extension decides)
 	sendMsg = &banktypes.MsgSend{
 		FromAddress: recipient2.String(),
 		ToAddress:   admin.String(),

--- a/integration-tests/modules/assetft_extension_test.go
+++ b/integration-tests/modules/assetft_extension_test.go
@@ -1654,9 +1654,9 @@ func TestAssetFTExtensionSendCommissionRate(t *testing.T) {
 	requireT.NotContains(txRes.RawLog, `{"key":"amount"}`)
 
 	assertCoinDistribution(ctx, chain.ClientContext, t, denom, map[*sdk.AccAddress]int64{
-		&admin:      580,
+		&admin:      580, // 1000 - 400 - 40 (10% commission from sender) + 20 (50% of the commission to the admin)
 		&recipient1: 400,
-		&extension:  20,
+		&extension:  20, // 50% of the commission to the extension
 	})
 
 	// send trigger amount from recipient1 to recipient2 (send commission rate must not apply)
@@ -1675,8 +1675,8 @@ func TestAssetFTExtensionSendCommissionRate(t *testing.T) {
 	requireT.NoError(err)
 	assertCoinDistribution(ctx, chain.ClientContext, t, denom, map[*sdk.AccAddress]int64{
 		&admin:      580,
-		&recipient1: 291,
-		&recipient2: 109,
+		&recipient1: 291, // 400 - 109 (AmountIgnoreSendCommissionRateTrigger)
+		&recipient2: 109, // AmountIgnoreSendCommissionRateTrigger
 		&extension:  20,
 	})
 
@@ -1695,10 +1695,10 @@ func TestAssetFTExtensionSendCommissionRate(t *testing.T) {
 	)
 	requireT.NoError(err)
 	assertCoinDistribution(ctx, chain.ClientContext, t, denom, map[*sdk.AccAddress]int64{
-		&admin:      585,
-		&recipient1: 181,
-		&recipient2: 209,
-		&extension:  25,
+		&admin:      585, // 580 + 5 (50% of the commission to the admin)
+		&recipient1: 181, // 291 - 100 - 10 (10% commission from sender)
+		&recipient2: 209, // 109 + 100
+		&extension:  25,  // 20 + 5 (50% of the commission to the extension)
 	})
 
 	// send from recipient2 to admin (send commission rate must apply if the extension decides)
@@ -1716,9 +1716,9 @@ func TestAssetFTExtensionSendCommissionRate(t *testing.T) {
 	)
 	requireT.NoError(err)
 	assertCoinDistribution(ctx, chain.ClientContext, t, denom, map[*sdk.AccAddress]int64{
-		&admin:      690,
+		&admin:      690, // 585 + 100 + 5 (50% of the commission to the admin)
 		&recipient1: 181,
-		&recipient2: 99,
-		&extension:  30,
+		&recipient2: 99, // 209 - 100 - 10 (10% commission from sender)
+		&extension:  30, // 25 + 5 (50% of the commission to the extension)
 	})
 }

--- a/x/asset/ft/keeper/keeper_extension_test.go
+++ b/x/asset/ft/keeper/keeper_extension_test.go
@@ -1002,8 +1002,8 @@ func TestKeeper_Extension_SendCommissionRate_BankSend(t *testing.T) {
 
 	ba.assertCoinDistribution(denom, map[*sdk.AccAddress]int64{
 		&recipient: 500,
-		&admin:     62,
-		&extension: 63,
+		&admin:     62, // 625 - 500 - 125 (25% commission from sender) + 62 (50% of the commission to the admin)
+		&extension: 63, // 63 (50% of the commission to the extension)
 	})
 
 	// send trigger amount from recipient1 to recipient2 (send commission rate must not apply)
@@ -1014,8 +1014,8 @@ func TestKeeper_Extension_SendCommissionRate_BankSend(t *testing.T) {
 	requireT.NoError(err)
 
 	ba.assertCoinDistribution(denom, map[*sdk.AccAddress]int64{
-		&recipient:  391,
-		&recipient2: 109,
+		&recipient:  391, // 500 - 109 (AmountIgnoreSendCommissionRateTrigger)
+		&recipient2: 109, // AmountIgnoreSendCommissionRateTrigger
 		&admin:      62,
 		&extension:  63,
 	})
@@ -1027,10 +1027,10 @@ func TestKeeper_Extension_SendCommissionRate_BankSend(t *testing.T) {
 	requireT.NoError(err)
 
 	ba.assertCoinDistribution(denom, map[*sdk.AccAddress]int64{
-		&recipient:  266,
-		&recipient2: 209,
-		&admin:      74,
-		&extension:  76,
+		&recipient:  266, // 391 - 100 - 25 (25% commission rate from the sender)
+		&recipient2: 209, // 109 + 100
+		&admin:      74,  // 62 + 12 (50% of the commission to the admin)
+		&extension:  76,  // 63 + 13 (50% of the commission to the extension)
 	})
 
 	// send from recipient to admin account (send commission rate must apply if the extension decides)
@@ -1040,10 +1040,10 @@ func TestKeeper_Extension_SendCommissionRate_BankSend(t *testing.T) {
 	requireT.NoError(err)
 
 	ba.assertCoinDistribution(denom, map[*sdk.AccAddress]int64{
-		&recipient:  141,
+		&recipient:  141, // 266 - 100 - 25 (25% commission rate from the sender)
 		&recipient2: 209,
-		&admin:      186,
-		&extension:  89,
+		&admin:      186, // 74 + 100 + 12 (50% of the commission to the admin)
+		&extension:  89,  // 76 + 13 (50% of the commission to the extension)
 	})
 
 	// clear admin, query admin of definition
@@ -1060,10 +1060,10 @@ func TestKeeper_Extension_SendCommissionRate_BankSend(t *testing.T) {
 	requireT.NoError(err)
 
 	ba.assertCoinDistribution(denom, map[*sdk.AccAddress]int64{
-		&recipient:  1,
+		&recipient:  1, // 141 - 112 - 28 (25% commission rate from the sender)
 		&recipient2: 321,
-		&admin:      186,
-		&extension:  117,
+		&admin:      186, // previous admin does not receive anything
+		&extension:  117, // 89 + 28 (100% of the commission to the extension, since there is no admin)
 	})
 }
 

--- a/x/asset/ft/keeper/keeper_extension_test.go
+++ b/x/asset/ft/keeper/keeper_extension_test.go
@@ -25,13 +25,13 @@ import (
 )
 
 const (
-	AmountDisallowedTrigger           = 7
-	AmountIgnoreWhitelistingTrigger   = 49
-	AmountIgnoreFreezingTrigger       = 79
-	AmountBurningTrigger              = 101
-	AmountMintingTrigger              = 105
-	AmountIgnoreBurnRateTrigger       = 108
-	AmountIgnoreCommissionRateTrigger = 109
+	AmountDisallowedTrigger               = 7
+	AmountIgnoreWhitelistingTrigger       = 49
+	AmountIgnoreFreezingTrigger           = 79
+	AmountBurningTrigger                  = 101
+	AmountMintingTrigger                  = 105
+	AmountIgnoreBurnRateTrigger           = 108
+	AmountIgnoreSendCommissionRateTrigger = 109
 )
 
 func TestKeeper_Extension_Issue(t *testing.T) {
@@ -1009,7 +1009,7 @@ func TestKeeper_Extension_SendCommissionRate_BankSend(t *testing.T) {
 	// send trigger amount from recipient1 to recipient2 (send commission rate must not apply)
 	recipient2 := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
 	err = bankKeeper.SendCoins(ctx, recipient, recipient2, sdk.NewCoins(
-		sdk.NewCoin(denom, sdkmath.NewInt(AmountIgnoreCommissionRateTrigger)),
+		sdk.NewCoin(denom, sdkmath.NewInt(AmountIgnoreSendCommissionRateTrigger)),
 	))
 	requireT.NoError(err)
 

--- a/x/asset/ft/keeper/keeper_extension_test.go
+++ b/x/asset/ft/keeper/keeper_extension_test.go
@@ -25,12 +25,13 @@ import (
 )
 
 const (
-	AmountDisallowedTrigger         = 7
-	AmountIgnoreWhitelistingTrigger = 49
-	AmountIgnoreFreezingTrigger     = 79
-	AmountBurningTrigger            = 101
-	AmountMintingTrigger            = 105
-	AmountIgnoreBurnRateTrigger     = 108
+	AmountDisallowedTrigger           = 7
+	AmountIgnoreWhitelistingTrigger   = 49
+	AmountIgnoreFreezingTrigger       = 79
+	AmountBurningTrigger              = 101
+	AmountMintingTrigger              = 105
+	AmountIgnoreBurnRateTrigger       = 108
+	AmountIgnoreCommissionRateTrigger = 109
 )
 
 func TestKeeper_Extension_Issue(t *testing.T) {
@@ -945,6 +946,125 @@ func TestKeeper_Extension_BurnRate_BankMultiSend(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestKeeper_Extension_SendCommissionRate_BankSend(t *testing.T) {
+	requireT := require.New(t)
+
+	testApp := simapp.New()
+	ctx := testApp.BaseApp.NewContext(false, tmproto.Header{
+		Time:    time.Now(),
+		AppHash: []byte("some-hash"),
+	})
+
+	assetKeeper := testApp.AssetFTKeeper
+	bankKeeper := testApp.BankKeeper
+	ba := newBankAsserter(ctx, t, bankKeeper)
+
+	admin := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
+
+	codeID, _, err := testApp.WasmPermissionedKeeper.Create(
+		ctx, admin, testcontracts.AssetExtensionWasm, &wasmtypes.AllowEverybody,
+	)
+	requireT.NoError(err)
+
+	// issue token
+	settings := types.IssueSettings{
+		Issuer:        admin,
+		Symbol:        "DEF",
+		Subunit:       "def",
+		Precision:     6,
+		Description:   "DEF Desc",
+		InitialAmount: sdkmath.NewInt(625),
+		Features:      []types.Feature{types.Feature_extension},
+		ExtensionSettings: &types.ExtensionIssueSettings{
+			CodeId: codeID,
+		},
+		SendCommissionRate: sdk.MustNewDecFromStr("0.25"),
+	}
+
+	denom, err := assetKeeper.Issue(ctx, settings)
+	requireT.NoError(err)
+
+	token, err := assetKeeper.GetToken(ctx, denom)
+	requireT.NoError(err)
+
+	extension, err := sdk.AccAddressFromBech32(token.ExtensionCWAddress)
+	requireT.NoError(err)
+
+	recipient := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
+
+	// send from admin to recipient (send commission rate must apply if the extension decides)
+	err = bankKeeper.SendCoins(ctx, admin, recipient, sdk.NewCoins(
+		sdk.NewCoin(denom, sdkmath.NewInt(500)),
+	))
+	requireT.NoError(err)
+
+	ba.assertCoinDistribution(denom, map[*sdk.AccAddress]int64{
+		&recipient: 500,
+		&admin:     62,
+		&extension: 63,
+	})
+
+	// send trigger amount from recipient1 to recipient2 (send commission rate must not apply)
+	recipient2 := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
+	err = bankKeeper.SendCoins(ctx, recipient, recipient2, sdk.NewCoins(
+		sdk.NewCoin(denom, sdkmath.NewInt(AmountIgnoreCommissionRateTrigger)),
+	))
+	requireT.NoError(err)
+
+	ba.assertCoinDistribution(denom, map[*sdk.AccAddress]int64{
+		&recipient:  391,
+		&recipient2: 109,
+		&admin:      62,
+		&extension:  63,
+	})
+
+	// send from recipient1 to recipient2 (send commission rate must apply)
+	err = bankKeeper.SendCoins(ctx, recipient, recipient2, sdk.NewCoins(
+		sdk.NewCoin(denom, sdkmath.NewInt(100)),
+	))
+	requireT.NoError(err)
+
+	ba.assertCoinDistribution(denom, map[*sdk.AccAddress]int64{
+		&recipient:  266,
+		&recipient2: 209,
+		&admin:      74,
+		&extension:  76,
+	})
+
+	// send from recipient to admin account (send commission rate must apply if the extension decides)
+	err = bankKeeper.SendCoins(ctx, recipient, admin, sdk.NewCoins(
+		sdk.NewCoin(denom, sdkmath.NewInt(100)),
+	))
+	requireT.NoError(err)
+
+	ba.assertCoinDistribution(denom, map[*sdk.AccAddress]int64{
+		&recipient:  141,
+		&recipient2: 209,
+		&admin:      186,
+		&extension:  89,
+	})
+
+	// clear admin, query admin of definition
+	err = assetKeeper.ClearAdmin(ctx, admin, denom)
+	requireT.NoError(err)
+	def, err := assetKeeper.GetDefinition(ctx, denom)
+	requireT.NoError(err)
+	requireT.Empty(def.Admin)
+
+	// send from recipient1 to recipient2 (send commission rate must apply, but all of it should go to the extension)
+	err = bankKeeper.SendCoins(ctx, recipient, recipient2, sdk.NewCoins(
+		sdk.NewCoin(denom, sdkmath.NewInt(112)),
+	))
+	requireT.NoError(err)
+
+	ba.assertCoinDistribution(denom, map[*sdk.AccAddress]int64{
+		&recipient:  1,
+		&recipient2: 321,
+		&admin:      186,
+		&extension:  117,
+	})
 }
 
 func TestKeeper_Extension_ClearAdmin(t *testing.T) {

--- a/x/asset/ft/keeper/test-contracts/asset-extension/src/contract.rs
+++ b/x/asset/ft/keeper/test-contracts/asset-extension/src/contract.rs
@@ -2,6 +2,7 @@ use cosmwasm_std::{entry_point, StdError};
 use cosmwasm_std::{BalanceResponse, BankQuery, ContractInfoResponse, WasmQuery};
 use cosmwasm_std::{Binary, Coin, Deps, DepsMut, Env, MessageInfo, Response, StdResult, Uint128};
 use cw2::set_contract_version;
+use std::ops::Div;
 
 use crate::error::ContractError;
 use coreum_wasm_sdk::assetft::{
@@ -22,6 +23,7 @@ const AMOUNT_IGNORE_FREEZING_TRIGGER: Uint128 = Uint128::new(79);
 const AMOUNT_BURNING_TRIGGER: Uint128 = Uint128::new(101);
 const AMOUNT_MINTING_TRIGGER: Uint128 = Uint128::new(105);
 const AMOUNT_IGNORE_BURN_RATE_TRIGGER: Uint128 = Uint128::new(108);
+const AMOUNT_IGNORE_COMMISSION_RATE_TRIGGER: Uint128 = Uint128::new(109);
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
@@ -56,10 +58,18 @@ pub fn sudo(deps: DepsMut<CoreumQueries>, env: Env, msg: SudoMsg) -> CoreumResul
             sender,
             recipient,
             transfer_amount,
-            commission_amount: _,
+            commission_amount,
             burn_amount,
             context: _,
-        } => sudo_extension_transfer(deps, env, transfer_amount, sender, recipient, burn_amount),
+        } => sudo_extension_transfer(
+            deps,
+            env,
+            transfer_amount,
+            sender,
+            recipient,
+            commission_amount,
+            burn_amount,
+        ),
     }
 }
 
@@ -69,6 +79,7 @@ pub fn sudo_extension_transfer(
     amount: Uint128,
     sender: String,
     recipient: String,
+    commission_amount: Uint128,
     burn_amount: Uint128,
 ) -> CoreumResult<ContractError> {
     if amount == AMOUNT_DISALLOWED_TRIGGER {
@@ -121,6 +132,11 @@ pub fn sudo_extension_transfer(
     let mut response = Response::new()
         .add_attribute("method", "execute_transfer")
         .add_message(transfer_msg);
+
+    if !commission_amount.is_zero() {
+        response =
+            assert_commission_rate(response, sender.as_ref(), amount, &token, commission_amount)?;
+    }
 
     if !burn_amount.is_zero() {
         response = assert_burn_rate(response, sender.as_ref(), amount, &token, burn_amount)?;
@@ -246,6 +262,50 @@ fn assert_block_smart_contracts(
     }
 
     return Ok(());
+}
+
+fn assert_commission_rate(
+    response: Response<CoreumMsg>,
+    sender: &str,
+    amount: Uint128,
+    token: &Token,
+    commission_amount: Uint128,
+) -> CoreumResult<ContractError> {
+    if amount == AMOUNT_IGNORE_COMMISSION_RATE_TRIGGER {
+        let refund_commission_rate_msg = cosmwasm_std::BankMsg::Send {
+            to_address: sender.to_string(),
+            amount: vec![Coin {
+                amount: commission_amount,
+                denom: token.denom.to_string(),
+            }],
+        };
+
+        return Ok(response
+            .add_attribute("commission_rate_refund", commission_amount.to_string())
+            .add_message(refund_commission_rate_msg));
+    }
+
+    // if token has an admin, send half of the commission to the admin and let the extension keep
+    // the rest of the commission
+    if let Some(admin) = &token.admin {
+        let admin_commission_amount = commission_amount.div(Uint128::new(2));
+        let admin_commission_msg = cosmwasm_std::BankMsg::Send {
+            to_address: admin.to_string(),
+            amount: vec![Coin {
+                amount: admin_commission_amount,
+                denom: token.denom.to_string(),
+            }],
+        };
+        return Ok(response
+            .add_attribute(
+                "admin_commission_amount",
+                admin_commission_amount.to_string(),
+            )
+            .add_message(admin_commission_msg));
+    }
+
+    // else, let the extension keep all the commission
+    Ok(response)
 }
 
 fn assert_burn_rate(


### PR DESCRIPTION
# Description
Handle send commisson rate in extension.
It ignores commission rate if the send amount is 109. Else, it will send half of the commission rate to admin if there is one and keeps the rest

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/coreum/843)
<!-- Reviewable:end -->
