### PR TITLE
order matching refactoring & critical fixes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -4735,8 +4735,8 @@ the order's state.
 | `price` | [string](#string) |  |  `price is value of one unit of the base_denom expressed in terms of the quote_denom.`  |
 | `quantity` | [string](#string) |  |  `quantity is amount of the base base_denom being traded.`  |
 | `side` | [Side](#coreum.dex.v1.Side) |  |  `side is order side.`  |
-| `remaining_quantity` | [string](#string) |  |  `remaining_quantity is remaining filling quantity sell/buy.`  |
-| `remaining_balance` | [string](#string) |  |  `remaining_balance is remaining order balance.`  |
+| `remaining_quantity` | [string](#string) |  |  `TODO: rename to remaining_base_quantity - is remaining quantity of base denom which user wants to sell or buy.`  |
+| `remaining_balance` | [string](#string) |  |  `TODO: rename to remaining_spend_balance - is balance up to which user wants to spend to execute order (mostly needed for buy market order execution).`  |
 | `good_til` | [GoodTil](#coreum.dex.v1.GoodTil) |  |  `good_til is order good til`  |
 | `time_in_force` | [TimeInForce](#coreum.dex.v1.TimeInForce) |  |  `time_in_force is order time in force`  |
 | `reserve` | [cosmos.base.v1beta1.Coin](#cosmos.base.v1beta1.Coin) |  |  `reserve is the reserve required to save the order in the order book`  |
@@ -4784,8 +4784,8 @@ OrderBookRecord is a single order book record, it combines both key and value fr
 | `order_sequence` | [uint64](#uint64) |  |  `order_sequence is order sequence.`  |
 | `order_id` | [string](#string) |  |  `order ID provided by the creator.`  |
 | `account_number` | [uint64](#uint64) |  |  `account_number is account number which corresponds the order creator.`  |
-| `remaining_quantity` | [string](#string) |  |  `remaining_quantity is remaining filling quantity sell/buy.`  |
-| `remaining_balance` | [string](#string) |  |  `remaining_balance is remaining order balance.`  |
+| `remaining_quantity` | [string](#string) |  |  `TODO: rename to remaining_base_quantity - is remaining quantity of base denom which user wants to sell or buy.`  |
+| `remaining_balance` | [string](#string) |  |  `TODO: rename to remaining_spend_balance - is balance up to which user wants to spend to execute order (mostly needed for buy market order execution).`  |
 
 
 

--- a/docs/static/openapi.json
+++ b/docs/static/openapi.json
@@ -10184,11 +10184,11 @@
         },
         "remaining_quantity": {
           "type": "string",
-          "description": "remaining_quantity is remaining filling quantity sell/buy."
+          "description": "TODO: rename to remaining_base_quantity - is remaining quantity of base denom which user wants to sell or buy."
         },
         "remaining_balance": {
           "type": "string",
-          "description": "remaining_balance is remaining order balance."
+          "description": "TODO: rename to remaining_spend_balance - is balance up to which user wants to spend to execute order (mostly needed for buy market order execution)."
         },
         "good_til": {
           "$ref": "#/definitions/coreum.dex.v1.GoodTil",

--- a/go.mod
+++ b/go.mod
@@ -173,7 +173,7 @@ require (
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect
 	github.com/google/btree v1.1.3 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
+	github.com/google/go-cmp v0.6.0
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/orderedcode v0.0.1 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect

--- a/go.work.sum
+++ b/go.work.sum
@@ -1383,6 +1383,7 @@ github.com/gonum/lapack v0.0.0-20181123203213-e4cdc5a0bff9 h1:7qnwS9+oeSiOIsiUMa
 github.com/gonum/lapack v0.0.0-20181123203213-e4cdc5a0bff9/go.mod h1:XA3DeT6rxh2EAE789SSiSJNqxPaC0aE9J8NTOI0Jo/A=
 github.com/gonum/matrix v0.0.0-20181209220409-c518dec07be9 h1:V2IgdyerlBa/MxaEFRbV5juy/C3MGdj4ePi+g6ePIp4=
 github.com/gonum/matrix v0.0.0-20181209220409-c518dec07be9/go.mod h1:0EXg4mc1CNP0HCqCz+K4ts155PXIlUywf0wqN+GfPZw=
+github.com/google/btree v1.1.2/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/flatbuffers v1.12.1/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/flatbuffers v2.0.8+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-containerregistry v0.13.0 h1:y1C7Z3e149OJbOPDBxLYR8ITPz8dTKqQwjErKVHJC8k=

--- a/pkg/math/big/int.go
+++ b/pkg/math/big/int.go
@@ -47,7 +47,30 @@ func IntGTE(x, y *big.Int) bool {
 	return x.Cmp(y) != -1
 }
 
+// IntGTE returns true if x is greater than y.
+func IntGT(x, y *big.Int) bool {
+	return x.Cmp(y) == 1
+}
+
+// IntGTE returns true if x is less than y.
+func IntLT(x, y *big.Int) bool {
+	return x.Cmp(y) == -1
+}
+
+// IntEQ returns true if x is equal to y.
+func IntEQ(x, y *big.Int) bool {
+	return x.Cmp(y) == 0
+}
+
 // IntEqZero returns true if x is equal to zero.
 func IntEqZero(x *big.Int) bool {
 	return x.Sign() == 0
+}
+
+// IntMin returns minimal of x and y.
+func IntMin(x, y *big.Int) *big.Int {
+	if x.Cmp(y) < 0 {
+		return x
+	}
+	return y
 }

--- a/pkg/math/big/int.go
+++ b/pkg/math/big/int.go
@@ -48,12 +48,12 @@ func IntGTE(x, y *big.Int) bool {
 	return x.Cmp(y) != -1
 }
 
-// IntGTE returns true if x is greater than y.
+// IntGT returns true if x is greater than y.
 func IntGT(x, y *big.Int) bool {
 	return x.Cmp(y) == 1
 }
 
-// IntGTE returns true if x is less than y.
+// IntLT returns true if x is less than y.
 func IntLT(x, y *big.Int) bool {
 	return x.Cmp(y) == -1
 }

--- a/pkg/math/big/int.go
+++ b/pkg/math/big/int.go
@@ -25,6 +25,7 @@ func IntMul(x, y *big.Int) *big.Int {
 }
 
 // IntMulRatWithRemainder multiplies x *big.Int by y *big.Rat and returns *big.Int result with the remainder.
+// TODO(ysv): Double check all usages of this function inside keeper matching.
 func IntMulRatWithRemainder(x *big.Int, y *big.Rat) (*big.Int, *big.Int) {
 	num := IntMul(x, y.Num())
 	denom := y.Denom()

--- a/pkg/math/big/rat.go
+++ b/pkg/math/big/rat.go
@@ -66,3 +66,10 @@ func RatInv(x *big.Rat) *big.Rat {
 func RatIsZero(x *big.Rat) bool {
 	return x.Cmp(big.NewRat(0, 1)) == 0
 }
+
+func RatMin(x, y *big.Rat) *big.Rat {
+	if x.Cmp(y) < 0 {
+		return x
+	}
+	return y
+}

--- a/pkg/math/big/rat.go
+++ b/pkg/math/big/rat.go
@@ -67,7 +67,7 @@ func RatIsZero(x *big.Rat) bool {
 	return x.Cmp(big.NewRat(0, 1)) == 0
 }
 
-// IntMin returns minimal of x and y.
+// RatMin returns minimal of x and y.
 func RatMin(x, y *big.Rat) *big.Rat {
 	if x.Cmp(y) < 0 {
 		return x

--- a/pkg/math/big/rat.go
+++ b/pkg/math/big/rat.go
@@ -67,6 +67,7 @@ func RatIsZero(x *big.Rat) bool {
 	return x.Cmp(big.NewRat(0, 1)) == 0
 }
 
+// IntMin returns minimal of x and y.
 func RatMin(x, y *big.Rat) *big.Rat {
 	if x.Cmp(y) < 0 {
 		return x

--- a/pkg/math/big/rat.go
+++ b/pkg/math/big/rat.go
@@ -61,3 +61,8 @@ func RatLT(x, y *big.Rat) bool {
 func RatInv(x *big.Rat) *big.Rat {
 	return (&big.Rat{}).Inv(x)
 }
+
+// RatIsZero returns true if x is equal to zero.
+func RatIsZero(x *big.Rat) bool {
+	return x.Cmp(big.NewRat(0, 1)) == 0
+}

--- a/proto/coreum/dex/v1/order.proto
+++ b/proto/coreum/dex/v1/order.proto
@@ -84,12 +84,12 @@ message Order {
   ];
   // side is order side.
   Side side = 9;
-  // remaining_quantity is remaining filling quantity sell/buy.
+  // TODO: rename to remaining_base_quantity - is remaining quantity of base denom which user wants to sell or buy.
   string remaining_quantity = 10 [
     (gogoproto.customtype) = "cosmossdk.io/math.Int",
     (gogoproto.nullable) = false
   ];
-  // remaining_balance is remaining order balance.
+  // TODO: rename to remaining_spend_balance - is balance up to which user wants to spend to execute order (mostly needed for buy market order execution).
   string remaining_balance = 11 [
     (gogoproto.customtype) = "cosmossdk.io/math.Int",
     (gogoproto.nullable) = false
@@ -157,12 +157,12 @@ message OrderBookRecord {
   string order_id = 5 [(gogoproto.customname) = "OrderID"];
   // account_number is account number which corresponds the order creator.
   uint64 account_number = 6;
-  // remaining_quantity is remaining filling quantity sell/buy.
+  // TODO: rename to remaining_base_quantity - is remaining quantity of base denom which user wants to sell or buy.
   string remaining_quantity = 7 [
     (gogoproto.customtype) = "cosmossdk.io/math.Int",
     (gogoproto.nullable) = false
   ];
-  // remaining_balance is remaining order balance.
+  // TODO: rename to remaining_spend_balance - is balance up to which user wants to spend to execute order (mostly needed for buy market order execution).
   string remaining_balance = 8 [
     (gogoproto.customtype) = "cosmossdk.io/math.Int",
     (gogoproto.nullable) = false

--- a/x/dex/keeper/cached_account_keeper.go
+++ b/x/dex/keeper/cached_account_keeper.go
@@ -22,8 +22,8 @@ func newCachedAccountKeeper(accountKeeper types.AccountKeeper, accountQueryServe
 	}
 }
 
-func (cak cachedAccountKeeper) getAccountAddress(ctx sdk.Context, accNumber uint64) (sdk.AccAddress, error) {
-	addr, err := cak.accountQueryServer.AccountAddressByID(
+func (cachedAccKeeper cachedAccountKeeper) getAccountAddress(ctx sdk.Context, accNumber uint64) (sdk.AccAddress, error) {
+	addr, err := cachedAccKeeper.accountQueryServer.AccountAddressByID(
 		ctx,
 		&authtypes.QueryAccountAddressByIDRequest{AccountId: accNumber},
 	)
@@ -39,18 +39,18 @@ func (cak cachedAccountKeeper) getAccountAddress(ctx sdk.Context, accNumber uint
 	return acc, nil
 }
 
-func (cak cachedAccountKeeper) getAccountAddressWithCache(ctx sdk.Context, accNumber uint64) (
+func (cachedAccKeeper cachedAccountKeeper) getAccountAddressWithCache(ctx sdk.Context, accNumber uint64) (
 	sdk.AccAddress,
 	error,
 ) {
-	addr, ok := cak.cache[accNumber]
+	addr, ok := cachedAccKeeper.cache[accNumber]
 	if !ok {
 		var err error
-		addr, err = cak.getAccountAddress(ctx, accNumber)
+		addr, err = cachedAccKeeper.getAccountAddress(ctx, accNumber)
 		if err != nil {
 			return nil, err
 		}
-		cak.cache[accNumber] = addr
+		cachedAccKeeper.cache[accNumber] = addr
 	}
 
 	return addr, nil

--- a/x/dex/keeper/cached_account_keeper.go
+++ b/x/dex/keeper/cached_account_keeper.go
@@ -1,0 +1,57 @@
+package keeper
+
+import (
+	sdkerrors "cosmossdk.io/errors"
+	"github.com/CoreumFoundation/coreum/v5/x/dex/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+)
+
+type cachedAccountKeeper struct {
+	accountKeeper      types.AccountKeeper
+	accountQueryServer types.AccountQueryServer
+
+	cache map[uint64]sdk.AccAddress
+}
+
+func newCachedAccountKeeper(accountKeeper types.AccountKeeper, accountQueryServer types.AccountQueryServer) cachedAccountKeeper {
+	return cachedAccountKeeper{
+		accountKeeper:      accountKeeper,
+		accountQueryServer: accountQueryServer,
+		cache:              make(map[uint64]sdk.AccAddress),
+	}
+}
+
+func (cak cachedAccountKeeper) getAccountAddress(ctx sdk.Context, accNumber uint64) (sdk.AccAddress, error) {
+	addr, err := cak.accountQueryServer.AccountAddressByID(
+		ctx,
+		&authtypes.QueryAccountAddressByIDRequest{AccountId: accNumber},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	acc, err := sdk.AccAddressFromBech32(addr.AccountAddress)
+	if err != nil {
+		return nil, sdkerrors.Wrapf(types.ErrInvalidInput, "invalid address: %s", addr)
+	}
+
+	return acc, nil
+}
+
+func (cak cachedAccountKeeper) getAccountAddressWithCache(ctx sdk.Context, accNumber uint64) (
+	sdk.AccAddress,
+	error,
+) {
+	addr, ok := cak.cache[accNumber]
+	if !ok {
+		var err error
+		addr, err = cak.getAccountAddress(ctx, accNumber)
+		if err != nil {
+			return nil, err
+		}
+		cak.cache[accNumber] = addr
+	}
+
+	return addr, nil
+}

--- a/x/dex/keeper/cached_account_keeper.go
+++ b/x/dex/keeper/cached_account_keeper.go
@@ -2,9 +2,10 @@ package keeper
 
 import (
 	sdkerrors "cosmossdk.io/errors"
-	"github.com/CoreumFoundation/coreum/v5/x/dex/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+	"github.com/CoreumFoundation/coreum/v5/x/dex/types"
 )
 
 type cachedAccountKeeper struct {
@@ -14,7 +15,10 @@ type cachedAccountKeeper struct {
 	cache map[uint64]sdk.AccAddress
 }
 
-func newCachedAccountKeeper(accountKeeper types.AccountKeeper, accountQueryServer types.AccountQueryServer) cachedAccountKeeper {
+func newCachedAccountKeeper(
+	accountKeeper types.AccountKeeper,
+	accountQueryServer types.AccountQueryServer,
+) cachedAccountKeeper {
 	return cachedAccountKeeper{
 		accountKeeper:      accountKeeper,
 		accountQueryServer: accountQueryServer,
@@ -22,7 +26,10 @@ func newCachedAccountKeeper(accountKeeper types.AccountKeeper, accountQueryServe
 	}
 }
 
-func (cachedAccKeeper cachedAccountKeeper) getAccountAddress(ctx sdk.Context, accNumber uint64) (sdk.AccAddress, error) {
+func (cachedAccKeeper cachedAccountKeeper) getAccountAddress(
+	ctx sdk.Context,
+	accNumber uint64,
+) (sdk.AccAddress, error) {
 	addr, err := cachedAccKeeper.accountQueryServer.AccountAddressByID(
 		ctx,
 		&authtypes.QueryAccountAddressByIDRequest{AccountId: accNumber},

--- a/x/dex/keeper/keeper.go
+++ b/x/dex/keeper/keeper.go
@@ -230,7 +230,8 @@ func (k Keeper) GetAccountsOrders(
 	moduleStore := k.storeService.OpenKVStore(ctx)
 	store := prefix.NewStore(runtime.KVStoreAdapter(moduleStore), types.OrderIDToSequenceKeyPrefix)
 	orderBookIDToOrderBookData := make(map[uint32]types.OrderBookData)
-	accNumberToAddrCache := make(map[uint64]sdk.AccAddress)
+	cak := newCachedAccountKeeper(k.accountKeeper, k.accountQueryServer)
+
 	orders, pageRes, err := query.GenericFilteredPaginate(
 		k.cdc,
 		store,
@@ -243,7 +244,7 @@ func (k Keeper) GetAccountsOrders(
 			}
 
 			var acc sdk.AccAddress
-			acc, err = k.getAccountAddressWithCache(ctx, accNumber, accNumberToAddrCache)
+			acc, err = cak.getAccountAddressWithCache(ctx, accNumber)
 			if err != nil {
 				return nil, err
 			}
@@ -1052,7 +1053,7 @@ func (k Keeper) getPaginatedOrderBookOrders(
 
 	moduleStore := k.storeService.OpenKVStore(ctx)
 	store := prefix.NewStore(runtime.KVStoreAdapter(moduleStore), types.CreateOrderBookSideKey(orderBookID, side))
-	accNumberToAddrCache := make(map[uint64]sdk.AccAddress)
+	cak := newCachedAccountKeeper(k.accountKeeper, k.accountQueryServer)
 
 	orders, pageRes, err := query.GenericFilteredPaginate(
 		k.cdc,
@@ -1067,7 +1068,7 @@ func (k Keeper) getPaginatedOrderBookOrders(
 			}
 
 			var acc sdk.AccAddress
-			acc, err = k.getAccountAddressWithCache(ctx, record.AccountNumber, accNumberToAddrCache)
+			acc, err = cak.getAccountAddressWithCache(ctx, record.AccountNumber)
 			if err != nil {
 				return nil, err
 			}

--- a/x/dex/keeper/keeper.go
+++ b/x/dex/keeper/keeper.go
@@ -230,7 +230,7 @@ func (k Keeper) GetAccountsOrders(
 	moduleStore := k.storeService.OpenKVStore(ctx)
 	store := prefix.NewStore(runtime.KVStoreAdapter(moduleStore), types.OrderIDToSequenceKeyPrefix)
 	orderBookIDToOrderBookData := make(map[uint32]types.OrderBookData)
-	cak := newCachedAccountKeeper(k.accountKeeper, k.accountQueryServer)
+	cachedAccKeeper := newCachedAccountKeeper(k.accountKeeper, k.accountQueryServer)
 
 	orders, pageRes, err := query.GenericFilteredPaginate(
 		k.cdc,
@@ -244,7 +244,7 @@ func (k Keeper) GetAccountsOrders(
 			}
 
 			var acc sdk.AccAddress
-			acc, err = cak.getAccountAddressWithCache(ctx, accNumber)
+			acc, err = cachedAccKeeper.getAccountAddressWithCache(ctx, accNumber)
 			if err != nil {
 				return nil, err
 			}
@@ -1053,7 +1053,7 @@ func (k Keeper) getPaginatedOrderBookOrders(
 
 	moduleStore := k.storeService.OpenKVStore(ctx)
 	store := prefix.NewStore(runtime.KVStoreAdapter(moduleStore), types.CreateOrderBookSideKey(orderBookID, side))
-	cak := newCachedAccountKeeper(k.accountKeeper, k.accountQueryServer)
+	cachedAccKeeper := newCachedAccountKeeper(k.accountKeeper, k.accountQueryServer)
 
 	orders, pageRes, err := query.GenericFilteredPaginate(
 		k.cdc,
@@ -1068,7 +1068,7 @@ func (k Keeper) getPaginatedOrderBookOrders(
 			}
 
 			var acc sdk.AccAddress
-			acc, err = cak.getAccountAddressWithCache(ctx, record.AccountNumber)
+			acc, err = cachedAccKeeper.getAccountAddressWithCache(ctx, record.AccountNumber)
 			if err != nil {
 				return nil, err
 			}

--- a/x/dex/keeper/keeper_account.go
+++ b/x/dex/keeper/keeper_account.go
@@ -2,8 +2,9 @@ package keeper
 
 import (
 	sdkerrors "cosmossdk.io/errors"
-	"github.com/CoreumFoundation/coreum/v5/x/dex/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/CoreumFoundation/coreum/v5/x/dex/types"
 )
 
 func (k Keeper) getAccountNumber(ctx sdk.Context, addr sdk.AccAddress) (uint64, error) {

--- a/x/dex/keeper/keeper_account.go
+++ b/x/dex/keeper/keeper_account.go
@@ -2,10 +2,8 @@ package keeper
 
 import (
 	sdkerrors "cosmossdk.io/errors"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-
 	"github.com/CoreumFoundation/coreum/v5/x/dex/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 func (k Keeper) getAccountNumber(ctx sdk.Context, addr sdk.AccAddress) (uint64, error) {
@@ -15,38 +13,4 @@ func (k Keeper) getAccountNumber(ctx sdk.Context, addr sdk.AccAddress) (uint64, 
 	}
 
 	return acc.GetAccountNumber(), nil
-}
-
-func (k Keeper) getAccountAddress(ctx sdk.Context, accNumber uint64) (sdk.AccAddress, error) {
-	addr, err := k.accountQueryServer.AccountAddressByID(
-		ctx,
-		&authtypes.QueryAccountAddressByIDRequest{AccountId: accNumber},
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	acc, err := sdk.AccAddressFromBech32(addr.AccountAddress)
-	if err != nil {
-		return nil, sdkerrors.Wrapf(types.ErrInvalidInput, "invalid address: %s", addr)
-	}
-
-	return acc, nil
-}
-
-func (k Keeper) getAccountAddressWithCache(ctx sdk.Context, accNumber uint64, cache map[uint64]sdk.AccAddress) (
-	sdk.AccAddress,
-	error,
-) {
-	addr, ok := cache[accNumber]
-	if !ok {
-		var err error
-		addr, err = k.getAccountAddress(ctx, accNumber)
-		if err != nil {
-			return nil, err
-		}
-		cache[accNumber] = addr
-	}
-
-	return addr, nil
 }

--- a/x/dex/keeper/keeper_matching.go
+++ b/x/dex/keeper/keeper_matching.go
@@ -207,7 +207,7 @@ func (k Keeper) mathcRecordsV2(
 	if err != nil {
 		return false, err
 	}
-	fmt.Printf("resulting closeResult: %v \ntrade: %+v", closeResult.String(), trade)
+	fmt.Printf("resulting closeResult: %v \ntrade: %+v\n", closeResult.String(), trade)
 
 	// Exchange funds
 	makerAddr, err := cak.getAccountAddressWithCache(ctx, makerRecord.AccountNumber)

--- a/x/dex/keeper/keeper_matching.go
+++ b/x/dex/keeper/keeper_matching.go
@@ -80,7 +80,7 @@ func (k Keeper) matchOrder(
 			if err := k.applyMatchingResult(ctx, mr); err != nil {
 				return err
 			}
-			if takerRecord.RemainingBalance.IsZero() {
+			if takerRecord.IsFilled() {
 				return nil
 			}
 

--- a/x/dex/keeper/keeper_matching_result.go
+++ b/x/dex/keeper/keeper_matching_result.go
@@ -120,7 +120,7 @@ func (mr *MatchingResult) IncreaseTakerLimitsForRecord(
 	takerRecord *types.OrderBookRecord,
 ) error {
 	// if the order is filled fully
-	if takerRecord.RemainingBalance.IsZero() {
+	if takerRecord.IsFilled() {
 		return nil
 	}
 

--- a/x/dex/keeper/keeper_matching_result.go
+++ b/x/dex/keeper/keeper_matching_result.go
@@ -119,11 +119,6 @@ func (mr *MatchingResult) IncreaseTakerLimitsForRecord(
 	order types.Order,
 	takerRecord *types.OrderBookRecord,
 ) error {
-	// if the order is filled fully
-	if takerRecord.IsFilled() {
-		return nil
-	}
-
 	lockedCoin, err := types.ComputeLimitOrderLockedBalance(
 		order.Side, order.BaseDenom, order.QuoteDenom, takerRecord.RemainingQuantity, *order.Price,
 	)

--- a/x/dex/keeper/keeper_matching_test.go
+++ b/x/dex/keeper/keeper_matching_test.go
@@ -11,6 +11,7 @@ import (
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
+	"github.com/google/go-cmp/cmp"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
@@ -6398,7 +6399,7 @@ func TestKeeper_MatchOrders(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		if tt.name != "match_limit_directOB_close_two_makers_buy_and_and_taker_sell" {
+		if tt.name != "match_limit_directOB_maker_sell_taker_buy_close_maker_with_partial_filling" {
 			continue
 		}
 		t.Run(tt.name, func(t *testing.T) {
@@ -6464,7 +6465,7 @@ func TestKeeper_MatchOrders(t *testing.T) {
 			wantOrders := tt.wantOrders(testSet)
 			// set order reserve and order sequence for all orders
 			wantOrders = fillReserveAndOrderSequence(t, sdkCtx, testApp, wantOrders)
-			require.ElementsMatch(t, wantOrders, orders, "orders are not expected")
+			require.ElementsMatch(t, wantOrders, orders, "orders do not match: \n%s", cmp.Diff(wantOrders, orders))
 
 			availableBalances := make(map[string]sdk.Coins)
 			lockedBalances := make(map[string]sdk.Coins)

--- a/x/dex/keeper/keeper_matching_test.go
+++ b/x/dex/keeper/keeper_matching_test.go
@@ -6398,6 +6398,9 @@ func TestKeeper_MatchOrders(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		if tt.name != "match_market_invertedOB_maker_buy_taker_buy_with_partially_filling" {
+			continue
+		}
 		t.Run(tt.name, func(t *testing.T) {
 			logger := log.NewTestLogger(t)
 			testApp := simapp.New(simapp.WithCustomLogger(logger))

--- a/x/dex/keeper/keeper_matching_test.go
+++ b/x/dex/keeper/keeper_matching_test.go
@@ -2934,7 +2934,7 @@ func TestKeeper_MatchOrders(t *testing.T) {
 						testSet.orderReserveTimes(2),
 						sdk.NewInt64Coin(denom2, 380),
 					),
-					// not enough balance to cover both orders
+					// not enough balance to cover both orders so id2 will be matched partially.
 					testSet.acc2.String(): sdk.NewCoins(sdk.NewInt64Coin(denom1, 100+900-1)),
 				}
 			},
@@ -2985,8 +2985,8 @@ func TestKeeper_MatchOrders(t *testing.T) {
 						Quantity:          sdkmath.NewInt(900),
 						Side:              types.SIDE_BUY,
 						TimeInForce:       types.TIME_IN_FORCE_GTC,
-						RemainingQuantity: sdkmath.NewInt(900),
-						RemainingBalance:  sdkmath.NewInt(342),
+						RemainingQuantity: sdkmath.NewInt(50),
+						RemainingBalance:  sdkmath.NewInt(19),
 					},
 				}
 			},
@@ -2994,11 +2994,11 @@ func TestKeeper_MatchOrders(t *testing.T) {
 				return map[string]sdk.Coins{
 					testSet.acc1.String(): sdk.NewCoins(
 						testSet.orderReserve,
-						sdk.NewInt64Coin(denom1, 100),
+						sdk.NewInt64Coin(denom1, 100+850),
 					),
 					testSet.acc2.String(): sdk.NewCoins(
-						sdk.NewInt64Coin(denom1, 899),
-						sdk.NewInt64Coin(denom2, 38),
+						sdk.NewInt64Coin(denom1, 49),
+						sdk.NewInt64Coin(denom2, 38+323),
 					),
 				}
 			},
@@ -6399,7 +6399,7 @@ func TestKeeper_MatchOrders(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		if tt.name != "match_limit_directOB_maker_sell_taker_buy_close_maker_with_partial_filling" {
+		if tt.name != "match_market_invertedOB_maker_buy_taker_buy_with_partially_filling" {
 			continue
 		}
 		t.Run(tt.name, func(t *testing.T) {

--- a/x/dex/keeper/keeper_matching_test.go
+++ b/x/dex/keeper/keeper_matching_test.go
@@ -6398,7 +6398,7 @@ func TestKeeper_MatchOrders(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		if tt.name != "match_market_invertedOB_maker_buy_taker_buy_with_partially_filling" {
+		if tt.name != "match_limit_directOB_close_two_makers_buy_and_and_taker_sell" {
 			continue
 		}
 		t.Run(tt.name, func(t *testing.T) {
@@ -6464,7 +6464,7 @@ func TestKeeper_MatchOrders(t *testing.T) {
 			wantOrders := tt.wantOrders(testSet)
 			// set order reserve and order sequence for all orders
 			wantOrders = fillReserveAndOrderSequence(t, sdkCtx, testApp, wantOrders)
-			require.ElementsMatch(t, wantOrders, orders)
+			require.ElementsMatch(t, wantOrders, orders, "orders are not expected")
 
 			availableBalances := make(map[string]sdk.Coins)
 			lockedBalances := make(map[string]sdk.Coins)

--- a/x/dex/keeper/keeper_matching_test.go
+++ b/x/dex/keeper/keeper_matching_test.go
@@ -6442,9 +6442,6 @@ func TestKeeper_MatchOrders(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		// if tt.name != "not_fillable_orders_cancelled_right_after_creation" {
-		// 	continue
-		// }
 		t.Run(tt.name, func(t *testing.T) {
 			logger := log.NewTestLogger(t)
 			testApp := simapp.New(simapp.WithCustomLogger(logger))

--- a/x/dex/keeper/matching_engine.go
+++ b/x/dex/keeper/matching_engine.go
@@ -1,0 +1,85 @@
+package keeper
+
+import (
+	"math/big"
+
+	cbig "github.com/CoreumFoundation/coreum/v5/pkg/math/big"
+)
+
+var MarketOrderPrice = big.NewRat(-1, 1)
+
+type Trade struct {
+	Quantity *big.Int
+	Price    *big.Rat
+}
+
+type OrderSide int
+
+const (
+	BuyOrderSide OrderSide = iota
+	SellOrderSide
+)
+
+type OBRecord struct {
+	Side              OrderSide
+	Price             *big.Rat
+	RemainingQuantity *big.Int
+	RemainingBalance  *big.Int
+}
+
+type MatchType int
+
+const (
+	NoneMatchType MatchType = iota
+	CloseTaker
+	CloseMaker
+	CloseBoth
+)
+
+func match(takerRecord, makerRecord OBRecord) (Trade, MatchType, error) {
+	if takerRecord.Side == makerRecord.Side {
+		return Trade{}, NoneMatchType, nil
+	}
+
+	trade := Trade{Price: makerRecord.Price}
+
+	// TODO(ysv): Consider zero quantity.
+	takerQuantity := takerRecord.MaxTakerQuantityForPrice(makerRecord.Price)
+
+	matchType := NoneMatchType
+	if cbig.IntLT(takerQuantity, makerRecord.RemainingQuantity) {
+		matchType = CloseTaker
+		trade.Quantity = takerQuantity
+	} else if cbig.IntEQ(takerQuantity, makerRecord.RemainingQuantity) {
+		matchType = CloseBoth
+		trade.Quantity = takerQuantity
+	} else {
+		matchType = CloseMaker
+		trade.Quantity = makerRecord.RemainingQuantity
+	}
+
+	return trade, matchType, nil
+}
+
+func (obr OBRecord) MaxTakerQuantityForPrice(price *big.Rat) *big.Int {
+	// For limit order we execute RemainingQuantity fully.
+	if obr.IsLimit() {
+		return obr.RemainingQuantity
+	}
+
+	// For market sell orders we execute up to RemainingQuantity or RemainingBalance, whichever is filled first.
+	if obr.Side == SellOrderSide {
+		return cbig.IntMin(obr.RemainingQuantity, obr.RemainingBalance)
+	}
+
+	// For market buy orders we execute up to RemainingQuantity or RemainingBalance / Price, whichever is filled first.
+	// RemainingBalance / Price = RemainingBalance * Price^-1
+	// Reminder is not executable so we just round it down.
+	maxQuantityFromBalance, _ := cbig.IntMulRatWithRemainder(obr.RemainingBalance, cbig.RatInv(price))
+
+	return cbig.IntMin(obr.RemainingQuantity, maxQuantityFromBalance)
+}
+
+func (obr OBRecord) IsLimit() bool {
+	return !cbig.RatEQ(obr.Price, MarketOrderPrice)
+}

--- a/x/dex/keeper/matching_engine.go
+++ b/x/dex/keeper/matching_engine.go
@@ -112,7 +112,7 @@ func (obr OBRecord) MaxBaseQuantityForPrice(price *big.Rat) *big.Int {
 	}
 
 	// For market buy orders we execute up to BaseQuantity or SpendBalance / Price, whichever is filled first.
-	// RemainingBalance / Price = RemainingBalance * Price^-1
+	// SpendBalance / Price = SpendBalance * Price^-1
 	maxQuantityFromBalance, _ := cbig.IntMulRatWithRemainder(obr.SpendBalance, cbig.RatInv(price))
 
 	maxBaseQuantity, _ := computeMaxIntExecutionQuantityV2(price, cbig.IntMin(obr.BaseQuantity, maxQuantityFromBalance))

--- a/x/dex/keeper/matching_engine.go
+++ b/x/dex/keeper/matching_engine.go
@@ -48,6 +48,19 @@ const (
 	CloseBoth
 )
 
+func (cr CloseResult) String() string {
+	switch cr {
+	case CloseTaker:
+		return "CloseTaker"
+	case CloseMaker:
+		return "CloseMaker"
+	case CloseBoth:
+		return "CloseBoth"
+	default:
+		return "None"
+	}
+}
+
 func match(takerRecord, makerRecord OBRecord) (Trade, CloseResult, error) {
 	if takerRecord.Side == makerRecord.Side {
 		return Trade{}, NoneCloseType, nil

--- a/x/dex/keeper/matching_engine.go
+++ b/x/dex/keeper/matching_engine.go
@@ -90,7 +90,7 @@ func match(takerRecord, makerRecord OBRecord) (Trade, CloseResult, error) {
 
 	// But for matching executeion we use integers.
 	// TODO(ysv): Take zero quantity into consideration.
-	trade.BaseQuantity, trade.QuoteQuantity = ComputeMaxIntExecutionQuantityV2(
+	trade.BaseQuantity, trade.QuoteQuantity = computeMaxIntExecutionQuantity(
 		trade.Price,
 		cbig.IntQuo(baseQuantityRat.Num(), baseQuantityRat.Denom()),
 	)
@@ -122,38 +122,6 @@ func (obr OBRecord) MaxBaseQuantityForPrice(price *big.Rat) *big.Rat {
 	maxQuantityFromBalance := cbig.RatMul(obr.SpendBalance, cbig.RatInv(price))
 
 	return cbig.RatMin(obr.BaseQuantity, maxQuantityFromBalance)
-}
-
-// func (obr OBRecord) MaxBaseQuantityForPriceLeg(price *big.Rat) *big.Int {
-// 	// For limit order we execute BaseQuantity fully.
-// 	if obr.IsLimit() {
-// 		maxBaseQuantity, _ := computeMaxIntExecutionQuantityV2(price, obr.BaseQuantity)
-// 		return maxBaseQuantity
-// 	}
-
-// 	// For market sell orders we execute up to BaseQuantity or SpendBalance, whichever is filled first.
-// 	if obr.Side == SellOrderSide {
-// 		maxBaseQuantity, _ := computeMaxIntExecutionQuantityV2(price, cbig.IntMin(obr.BaseQuantity, obr.SpendBalance))
-// 		return maxBaseQuantity
-// 	}
-
-// 	// For market buy orders we execute up to BaseQuantity or SpendBalance / Price, whichever is filled first.
-// 	// SpendBalance / Price = SpendBalance * Price^-1
-// 	maxQuantityFromBalance, _ := cbig.IntMulRatWithRemainder(obr.SpendBalance, cbig.RatInv(price))
-
-// 	maxBaseQuantity, _ := computeMaxIntExecutionQuantityV2(price, cbig.IntMin(obr.BaseQuantity, maxQuantityFromBalance))
-// 	return maxBaseQuantity
-// }
-
-func ComputeMaxIntExecutionQuantityV2(priceRat *big.Rat, baseQuantity *big.Int) (*big.Int, *big.Int) {
-	priceNum := priceRat.Num()
-	priceDenom := priceRat.Denom()
-
-	n := cbig.IntQuo(baseQuantity, priceDenom)
-	baseIntQuantity := cbig.IntMul(n, priceDenom)
-	quoteIntQuantity := cbig.IntMul(n, priceNum)
-
-	return baseIntQuantity, quoteIntQuantity
 }
 
 func (obr OBRecord) IsLimit() bool {

--- a/x/dex/spec/README.md
+++ b/x/dex/spec/README.md
@@ -108,6 +108,8 @@ The `Qb'` is the opposite order's `max_execution_quantity` (the amount by which 
 opposite_execution_quantity = floor(remaining_quantity / price_denominator) * price_numerator
 ```
 
+This method is implemented inside `x/dex`. The func name is `func computeMaxExecutionQuantity`
+
 Let's return back to the example with the [Rounding issue](#Rounding-issue) :
 
 | order_id | base_denom | quote_denom | side | remaining_quantity | price |

--- a/x/dex/types/order.go
+++ b/x/dex/types/order.go
@@ -236,10 +236,6 @@ func (r OrderBookRecord) MaxBaseAmntForPrice(side Side, ordType OrderType, price
 	return maxAmntFromQty
 }
 
-func (r OrderBookRecord) IsFilled() bool {
-	return r.RemainingBalance.IsZero() || r.RemainingQuantity.IsZero()
-}
-
 // ComputeLimitOrderLockedBalance computes the limit order locked balance.
 func ComputeLimitOrderLockedBalance(
 	side Side, baseDenom, quoteDenom string, quantity sdkmath.Int, price Price,

--- a/x/dex/types/order.go
+++ b/x/dex/types/order.go
@@ -216,26 +216,6 @@ func (o Order) Denoms() []string {
 	return []string{o.BaseDenom, o.QuoteDenom}
 }
 
-// MaxBaseAmntForPrice returns max amount of base unit order can consume/match (receive or spend).
-// For sell limit order it should be equal to RemainingQuantity but for market it could be
-func (r OrderBookRecord) MaxBaseAmntForPrice(side Side, ordType OrderType, priceRat *big.Rat) *big.Rat {
-	// sell limit => remaining_quantity
-	// sell market => remaining_quantity
-	// buy limit => remaining_quantity
-	if side == SIDE_SELL || ordType == ORDER_TYPE_LIMIT {
-		return cbig.NewRatFromBigInt(r.RemainingQuantity.BigInt())
-	}
-
-	// buy market => min(RemainingBalance / price, remaining_quantity)
-	maxAmntFromBalance := cbig.RatMul(cbig.NewRatFromBigInt(r.RemainingBalance.BigInt()), cbig.RatInv(priceRat))
-	maxAmntFromQty := cbig.NewRatFromBigInt(r.RemainingQuantity.BigInt())
-
-	if cbig.RatLT(maxAmntFromBalance, maxAmntFromQty) {
-		return maxAmntFromBalance
-	}
-	return maxAmntFromQty
-}
-
 // ComputeLimitOrderLockedBalance computes the limit order locked balance.
 func ComputeLimitOrderLockedBalance(
 	side Side, baseDenom, quoteDenom string, quantity sdkmath.Int, price Price,

--- a/x/dex/types/order.go
+++ b/x/dex/types/order.go
@@ -236,6 +236,10 @@ func (r OrderBookRecord) MaxBaseAmntForPrice(side Side, ordType OrderType, price
 	return maxAmntFromQty
 }
 
+func (r OrderBookRecord) IsFilled() bool {
+	return r.RemainingBalance.IsZero() || r.RemainingQuantity.IsZero()
+}
+
 // ComputeLimitOrderLockedBalance computes the limit order locked balance.
 func ComputeLimitOrderLockedBalance(
 	side Side, baseDenom, quoteDenom string, quantity sdkmath.Int, price Price,

--- a/x/dex/types/order.go
+++ b/x/dex/types/order.go
@@ -216,6 +216,16 @@ func (o Order) Denoms() []string {
 	return []string{o.BaseDenom, o.QuoteDenom}
 }
 
+// MaxReceiveQuantityByPrice returns actual funded remaining quantity.
+// For sell limit order it should be equal to RemainingQuantity but for market it could be
+func (r OrderBookRecord) MaxReceiveQuantityByPrice(side Side, price Price) big.Rat {
+	// sell limit => remaining_quantity
+	// sell market => remaining_quantity
+
+	// buy limit =>
+	return big.Rat{}
+}
+
 // ComputeLimitOrderLockedBalance computes the limit order locked balance.
 func ComputeLimitOrderLockedBalance(
 	side Side, baseDenom, quoteDenom string, quantity sdkmath.Int, price Price,

--- a/x/dex/types/order.pb.go
+++ b/x/dex/types/order.pb.go
@@ -234,9 +234,9 @@ type Order struct {
 	Quantity cosmossdk_io_math.Int `protobuf:"bytes,8,opt,name=quantity,proto3,customtype=cosmossdk.io/math.Int" json:"quantity"`
 	// side is order side.
 	Side Side `protobuf:"varint,9,opt,name=side,proto3,enum=coreum.dex.v1.Side" json:"side,omitempty"`
-	// remaining_quantity is remaining filling quantity sell/buy.
+	// TODO: rename to remaining_base_quantity - is remaining quantity of base denom which user wants to sell or buy.
 	RemainingQuantity cosmossdk_io_math.Int `protobuf:"bytes,10,opt,name=remaining_quantity,json=remainingQuantity,proto3,customtype=cosmossdk.io/math.Int" json:"remaining_quantity"`
-	// remaining_balance is remaining order balance.
+	// TODO: rename to remaining_spend_balance - is balance up to which user wants to spend to execute order (mostly needed for buy market order execution).
 	RemainingBalance cosmossdk_io_math.Int `protobuf:"bytes,11,opt,name=remaining_balance,json=remainingBalance,proto3,customtype=cosmossdk.io/math.Int" json:"remaining_balance"`
 	// good_til is order good til
 	GoodTil *GoodTil `protobuf:"bytes,12,opt,name=good_til,json=goodTil,proto3" json:"good_til,omitempty"`
@@ -385,9 +385,9 @@ type OrderBookRecord struct {
 	OrderID string `protobuf:"bytes,5,opt,name=order_id,json=orderId,proto3" json:"order_id,omitempty"`
 	// account_number is account number which corresponds the order creator.
 	AccountNumber uint64 `protobuf:"varint,6,opt,name=account_number,json=accountNumber,proto3" json:"account_number,omitempty"`
-	// remaining_quantity is remaining filling quantity sell/buy.
+	// TODO: rename to remaining_base_quantity - is remaining quantity of base denom which user wants to sell or buy.
 	RemainingQuantity cosmossdk_io_math.Int `protobuf:"bytes,7,opt,name=remaining_quantity,json=remainingQuantity,proto3,customtype=cosmossdk.io/math.Int" json:"remaining_quantity"`
-	// remaining_balance is remaining order balance.
+	// TODO: rename to remaining_spend_balance - is balance up to which user wants to spend to execute order (mostly needed for buy market order execution).
 	RemainingBalance cosmossdk_io_math.Int `protobuf:"bytes,8,opt,name=remaining_balance,json=remainingBalance,proto3,customtype=cosmossdk.io/math.Int" json:"remaining_balance"`
 }
 

--- a/x/dex/types/price.go
+++ b/x/dex/types/price.go
@@ -119,6 +119,7 @@ func (p Price) Rat() *big.Rat {
 	)
 }
 
+// Equal returns true if prices are equal.
 func (p Price) Equal(p2 Price) bool {
 	return p.exp == p2.exp && p.num == p2.num
 }

--- a/x/dex/types/price.go
+++ b/x/dex/types/price.go
@@ -119,6 +119,10 @@ func (p Price) Rat() *big.Rat {
 	)
 }
 
+func (p Price) Equal(p2 Price) bool {
+	return p.exp == p2.exp && p.num == p2.num
+}
+
 // MarshallToOrderedBytes returns the ordered bytes representation of the Price.
 func (p Price) MarshallToOrderedBytes() ([]byte, error) {
 	exp, num, err := normalizeForOrderedBytes(p.exp, p.num)


### PR DESCRIPTION
# Description

Significant changes:
- Invert maker order before matching if side is the same
- Fixed market order execution to allow partial fill of limit order
- Automatically cancel orders if amount is non-executable for both taker & maker orders

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/coreum/1074)
<!-- Reviewable:end -->
