### PR TITLE
feat: enforce 5% minimum validator commission rate

### DIFF
--- a/proto/coreum/customparams/v1/params.proto
+++ b/proto/coreum/customparams/v1/params.proto
@@ -1,23 +1,2 @@
-syntax = "proto3";
-package coreum.customparams.v1;
 
-import "gogoproto/gogo.proto";
 
-option go_package = "github.com/CoreumFoundation/coreum/v6/x/customparams/types";
-
-// StakingParams defines the set of additional staking params for the staking module wrapper.
-message StakingParams {
-  // min_self_delegation is the validators global self declared minimum for delegation.
-  string min_self_delegation = 1 [
-    (gogoproto.moretags) = "yaml:\"min_self_delegation\"",
-    (gogoproto.customtype) = "cosmossdk.io/math.Int",
-    (gogoproto.nullable) = false
-  ];
-
-  // min_commission_rate is the minimum commission rate required for validators.
-  string min_commission_rate = 2 [
-    (gogoproto.moretags) = "yaml:\"min_commission_rate\"",
-    (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec", 
-    (gogoproto.nullable) = false
-  ];
-}

--- a/proto/coreum/customparams/v1/params.proto
+++ b/proto/coreum/customparams/v1/params.proto
@@ -13,4 +13,11 @@ message StakingParams {
     (gogoproto.customtype) = "cosmossdk.io/math.Int",
     (gogoproto.nullable) = false
   ];
+
+  // min_commission_rate is the minimum commission rate required for validators.
+  string min_commission_rate = 2 [
+    (gogoproto.moretags) = "yaml:\"min_commission_rate\"",
+    (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec", 
+    (gogoproto.nullable) = false
+  ];
 }

--- a/x/customparams/types/params.go
+++ b/x/customparams/types/params.go
@@ -30,7 +30,10 @@ func (p *StakingParams) ParamSetPairs() paramtypes.ParamSetPairs {
 
 // ValidateBasic performs basic validation on staking parameters.
 func (p StakingParams) ValidateBasic() error {
-	return validateMinSelfDelegation(p.MinSelfDelegation)
+	if err := validateMinSelfDelegation(p.MinSelfDelegation); err != nil {
+		return err
+	}
+	return validateMinCommissionRate(p.MinCommissionRate)
 }
 
 func validateMinSelfDelegation(i interface{}) error {
@@ -44,6 +47,31 @@ func validateMinSelfDelegation(i interface{}) error {
 	}
 	if !v.IsPositive() {
 		return errors.Errorf("param min_self_delegation must be positive: %s", v)
+	}
+
+	return nil
+}
+
+// Add this new function to enforce the 5% floor
+func validateMinCommissionRate(i interface{}) error {
+	v, ok := i.(sdk.Dec)
+	if !ok {
+		return errors.Errorf("invalid parameter type: %T", i)
+	}
+
+	if v.IsNil() {
+		return errors.New("param min_commission_rate must be not nil")
+	}
+
+	// Define the 5% floor (0.05)
+	minAllowed := sdk.NewDecWithPrec(5, 2)
+
+	if v.LT(minAllowed) {
+		return errors.Errorf("param min_commission_rate cannot be lower than %s (5%%)", minAllowed)
+	}
+
+	if v.GT(sdk.OneDec()) {
+		return errors.New("param min_commission_rate cannot be greater than 1 (100%)")
 	}
 
 	return nil

--- a/x/customparams/types/params.go
+++ b/x/customparams/types/params.go
@@ -2,29 +2,35 @@ package types
 
 import (
 	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types" // <--- 1. ADD THIS IMPORT
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	"github.com/pkg/errors"
 )
 
-// ParamStoreKeyMinSelfDelegation defines the param key for the min_self_delegation param.
-var ParamStoreKeyMinSelfDelegation = []byte("minselfdelegation")
+// 2. ADD THE NEW KEY HERE
+var (
+	ParamStoreKeyMinSelfDelegation = []byte("minselfdelegation")
+	ParamStoreKeyMinCommissionRate = []byte("mincommissionrate")
+)
 
 // StakingParamKeyTable returns the parameter key table.
 func StakingParamKeyTable() paramtypes.KeyTable {
 	return paramtypes.NewKeyTable().RegisterParamSet(&StakingParams{})
 }
 
-// DefaultStakingParams returns default staking parameters.
+// 3. UPDATE DEFAULT PARAMS HERE
 func DefaultStakingParams() StakingParams {
 	return StakingParams{
 		MinSelfDelegation: sdkmath.OneInt(),
+		MinCommissionRate: sdk.NewDecWithPrec(5, 2), // Sets default to 5%
 	}
 }
 
-// ParamSetPairs returns the parameter set pairs.
+// 4. REGISTER THE NEW PARAMETER HERE
 func (p *StakingParams) ParamSetPairs() paramtypes.ParamSetPairs {
 	return paramtypes.ParamSetPairs{
 		paramtypes.NewParamSetPair(ParamStoreKeyMinSelfDelegation, &p.MinSelfDelegation, validateMinSelfDelegation),
+		paramtypes.NewParamSetPair(ParamStoreKeyMinCommissionRate, &p.MinCommissionRate, validateMinCommissionRate),
 	}
 }
 
@@ -52,7 +58,7 @@ func validateMinSelfDelegation(i interface{}) error {
 	return nil
 }
 
-// Add this new function to enforce the 5% floor
+// validateMinCommissionRate enforces the 5% floor
 func validateMinCommissionRate(i interface{}) error {
 	v, ok := i.(sdk.Dec)
 	if !ok {


### PR DESCRIPTION
This PR introduces a protocol-level requirement for a minimum validator commission rate of 5%. This change is designed to ensure network security and validator sustainability by preventing a "race to the bottom" in commission rates.

Changes:

Proto Definition: Updated StakingParams in params.proto to include min_commission_rate using cosmossdk.io/math.LegacyDec.

Validation: Added validateMinCommissionRate in params.go to enforce the 0.05 (5%) floor during parameter updates and ValidateBasic checks.

Defaults: Updated DefaultStakingParams to set the initial floor to 5%.

Note on Code Generation: I have manually updated the .proto and logic files. However, make generate failed in my environment due to a compatibility issue with github.com/bytedance/sonic (GoMapIterator error). I am submitting the source changes so the CI or a maintainer with a compatible build environment can sync the generated .pb.go files.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/coreum/1177)
<!-- Reviewable:end -->
